### PR TITLE
Rename exclude to excludeWhen, use null / false

### DIFF
--- a/adtl/__init__.py
+++ b/adtl/__init__.py
@@ -50,7 +50,7 @@ def get_value_unhashed(row: StrDict, rule: Rule) -> Any:
         value = row[rule["field"]]
         if "values" in rule:
             value = rule["values"].get(value)
-        # Either source_unit / unit OR source_date / date triggers conversion
+        # Either source_unit`` / unit OR source_date / date triggers conversion
         if "source_unit" in rule and "unit" in rule:
             assert "source_date" not in rule and "date" not in rule
             source_unit = get_value(row, rule["source_unit"])
@@ -135,13 +135,9 @@ def get_list(row: StrDict, rule: StrDict) -> List[Any]:
     assert "fields" in rule
     assert len(rule["fields"]) >= 1
     rules = []
-    exclude = rule.get("exclude")
-    if (
-        exclude is not None
-        and exclude not in ["null", "falsy"]
-        and not isinstance(exclude, list)
-    ):
-        raise ValueError("exclude rule should be 'null', 'falsy' or a list of values")
+    excludeWhen = rule.get("excludeWhen", ...)  # use ... as sentinel
+    if excludeWhen not in [None, False, ...] and not isinstance(excludeWhen, list):
+        raise ValueError("excludeWhen rule should be null, false, or a list of values")
 
     # expand fieldPattern rules
     for r in rule["fields"]:
@@ -151,14 +147,14 @@ def get_list(row: StrDict, rule: StrDict) -> List[Any]:
         else:
             rules.append(r)
     values = [get_value(row, r) for r in rules]
-    if exclude is None:
+    if excludeWhen == ...:
         return values
-    if exclude == "null":
+    if excludeWhen is None:
         return [v for v in values if v is not None]
-    elif exclude == "falsy":
+    elif excludeWhen is False:
         return [v for v in values if v]
     else:
-        return [v for v in values if v not in exclude]
+        return [v for v in values if v not in excludeWhen]
 
 
 def get_combined_type(row: StrDict, rule: StrDict):

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -246,10 +246,9 @@ such as hashing the field.
   }
   ```
 
-  List fields can have an optional *exclude* key which can either be a list or values
-  or the strings `null | falsy`. The exclude key can be `null` in which cases we drop the null values (None in Python) or it can be `falsy`in which case falsy values are excluded (empty lists, boolean False, 0). Alternatively a list of values to be excluded can be provided.
+  **excludeWhen**: List fields can have an optional *excludeWhen* key which can either be a list of values or `null` or `false`. When it is `null` we drop the null values (None in Python) or it can be `false` in which case falsy values are excluded (empty lists, boolean False, 0). Alternatively a list of values to be excluded can be provided.
 
-  If the exclude attribute is not set, no exclusions take place and all values are returned as-is.
+  If *excludeWhen* is not set, no exclusions take place and all values are returned as-is.
 
 * **Conditional rows**: For the *oneToMany* case, each row in the source file generates
   multiple rows for the target. This is expressed in the specification by making the

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -103,7 +103,7 @@ female,001,dataset-2020-03-23,GBR,2022-01-11,2020-06-08
         (
             (
                 {"modliv": "1", "mildliver": "3"},
-                {**RULE_COMBINED_TYPE_LIST_PATTERN, "exclude": "null"},
+                {**RULE_COMBINED_TYPE_LIST_PATTERN, "excludeWhen": None},
             ),
             [True],
         ),
@@ -213,9 +213,9 @@ def test_invalid_operand_parse_if():
     "rowrule,expected",
     [
         ((ROW_CONCISE, RULE_EXCLUDE), [0, 2]),
-        ((ROW_CONCISE, {**RULE_EXCLUDE, "exclude": "falsy"}), [2]),
-        ((ROW_CONCISE, {**RULE_EXCLUDE, "exclude": "null"}), [0, 2]),
-        ((ROW_CONCISE, {**RULE_EXCLUDE, "exclude": [2]}), [0]),
+        ((ROW_CONCISE, {**RULE_EXCLUDE, "excludeWhen": False}), [2]),
+        ((ROW_CONCISE, {**RULE_EXCLUDE, "excludeWhen": None}), [0, 2]),
+        ((ROW_CONCISE, {**RULE_EXCLUDE, "excludeWhen": [2]}), [0]),
     ],
 )
 def test_list_exclude(rowrule, expected):
@@ -224,14 +224,14 @@ def test_list_exclude(rowrule, expected):
 
 def test_invalid_list_exclude():
     with pytest.raises(
-        ValueError, match="exclude rule should be 'null', 'falsy' or a list of values"
+        ValueError, match="excludeWhen rule should be null, false, or a list of values"
     ):
         parser.get_list(
             {"modliv": 1, "mildliv": 2},
             {
                 "combinedType": "list",
                 "fields": [{"field": "modliv"}, {"field": "mildliv"}],
-                "exclude": 5,
+                "excludeWhen": 5,
             },
         )
 


### PR DESCRIPTION
Using string quoted null and falsy can be confused with the
similar unquoted null and false values that are valid JSON.
