### PR TITLE
Move header into adtl key, remove # in defs/refs/if

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -10,7 +10,7 @@ created in parallel from one source file.
 
 ## metadata
 
-**Required fields**. These metadata fields are defined at the top level of the specification
+**Required fields**. These metadata fields are defined under a header key `adtl`.
 
 * **name**: Name of the specification, usually the source data name in
   lowercase and hyphenated. By convention, this is the same name as the
@@ -29,7 +29,7 @@ created in parallel from one source file.
     type*lastNotNull* is supported which sets a particular
     attribute to the last non-null value in the grouped dataset.
 
-* **#defs**: Definitions that can be referred to elsewhere in the schema
+* **defs**: Definitions that can be referred to elsewhere in the schema
 
 ## references
 
@@ -38,21 +38,23 @@ Often, a part of the schema is repeated, and it is better to
 supports references anywhere a dictionary or object is allowed:
 
 ```json
-{ "#ref": "someReference" }
+{ "ref": "someReference" }
 ```
 
 This would require a `someReference` key within the top-level definitions section:
 
 ```json
 {
-  "name": "parser",
-  "tables": {
-    "someTable": {
-      "groupBy": "subjid",
-      "aggregation": "lastNotNull"
+  "adtl": {
+    "name": "parser",
+    "tables": {
+      "someTable": {
+        "groupBy": "subjid",
+        "aggregation": "lastNotNull"
+      }
     }
   },
-  "#defs": {
+  "defs": {
     "someReference": {
       "values": {
         "1": true,
@@ -258,7 +260,7 @@ such as hashing the field.
 * **Conditional rows**: For the *oneToMany* case, each row in the source file generates
   multiple rows for the target. This is expressed in the specification by making the
   value corresponding to the table key a list instead of an object. Additionally
-  an `#if` key sets the condition under which the row is emitted.
+  an `if` key sets the condition under which the row is emitted.
 
   ```json
   {
@@ -268,7 +270,7 @@ such as hashing the field.
           "field": "dsstdtc"
         },
         "name": "headache",
-        "#if": {
+        "if": {
           "headache_symptom": 1
         }
       },
@@ -277,7 +279,7 @@ such as hashing the field.
           "field": "dsstdtc"
         },
         "name": "cough",
-        "#if": {
+        "if": {
           "cough_symptoms": 1
         }
       }

--- a/tests/parsers/constant.json
+++ b/tests/parsers/constant.json
@@ -1,9 +1,11 @@
 {
-    "name": "constant",
-    "description": "Fixed table",
-    "tables": {
-        "metadata": {
-            "kind": "constant"
+    "adtl": {
+        "name": "constant",
+        "description": "Fixed table",
+        "tables": {
+            "metadata": {
+                "kind": "constant"
+            }
         }
     },
     "metadata": {

--- a/tests/parsers/groupBy-defs.json
+++ b/tests/parsers/groupBy-defs.json
@@ -1,25 +1,27 @@
 {
-    "name": "groupBy",
-    "description": "Example using groupBy",
-    "#defs": {
-        "sexMapping": {
-            "values": {
-                "1": "male",
-                "2": "female",
-                "3": "non_binary"
+    "adtl": {
+        "name": "groupBy",
+        "description": "Example using groupBy",
+        "defs": {
+            "sexMapping": {
+                "values": {
+                    "1": "male",
+                    "2": "female",
+                    "3": "non_binary"
+                }
             }
-        }
-    },
-    "tables": {
-        "subject": {
-            "kind": "groupBy",
-            "groupBy": "subject_id",
-            "aggregation": "lastNotNull"
+        },
+        "tables": {
+            "subject": {
+                "kind": "groupBy",
+                "groupBy": "subject_id",
+                "aggregation": "lastNotNull"
+            }
         }
     },
     "subject": {
         "sex_at_birth": {
-            "#ref": "sexMapping",
+            "ref": "sexMapping",
             "field": "sex",
             "description": "Sex at Birth"
         },

--- a/tests/parsers/groupBy-incorrect-aggregation.json
+++ b/tests/parsers/groupBy-incorrect-aggregation.json
@@ -1,11 +1,13 @@
 {
-    "name": "groupBy",
-    "description": "Example using groupBy",
-    "tables": {
-        "subject": {
-            "kind": "groupBy",
-            "groupBy": "subject_id",
-            "aggregation": "foobar"
+    "adtl": {
+        "name": "groupBy",
+        "description": "Example using groupBy",
+        "tables": {
+            "subject": {
+                "kind": "groupBy",
+                "groupBy": "subject_id",
+                "aggregation": "foobar"
+            }
         }
     },
     "subject": {

--- a/tests/parsers/groupBy-missing-kind.json
+++ b/tests/parsers/groupBy-missing-kind.json
@@ -1,10 +1,12 @@
 {
-    "name": "groupBy",
-    "description": "Example using groupBy",
-    "tables": {
-        "subject": {
-            "groupBy": "subject_id",
-            "aggregation": "lastNotNull"
+    "adtl": {
+        "name": "groupBy",
+        "description": "Example using groupBy",
+        "tables": {
+            "subject": {
+                "groupBy": "subject_id",
+                "aggregation": "lastNotNull"
+            }
         }
     },
     "subject": {

--- a/tests/parsers/groupBy-missing-table.json
+++ b/tests/parsers/groupBy-missing-table.json
@@ -1,11 +1,13 @@
 {
-    "name": "groupBy",
-    "description": "Example using groupBy",
-    "tables": {
-        "subject": {
-            "kind": "groupBy",
-            "groupBy": "subject_id",
-            "aggregation": "lastNotNull"
+    "adtl": {
+        "name": "groupBy",
+        "description": "Example using groupBy",
+        "tables": {
+            "subject": {
+                "kind": "groupBy",
+                "groupBy": "subject_id",
+                "aggregation": "lastNotNull"
+            }
         }
     }
 }

--- a/tests/parsers/groupBy.json
+++ b/tests/parsers/groupBy.json
@@ -1,11 +1,13 @@
 {
-    "name": "groupBy",
-    "description": "Example using groupBy",
-    "tables": {
-        "subject": {
-            "kind": "groupBy",
-            "groupBy": "subject_id",
-            "aggregation": "lastNotNull"
+    "adtl": {
+        "name": "groupBy",
+        "description": "Example using groupBy",
+        "tables": {
+            "subject": {
+                "kind": "groupBy",
+                "groupBy": "subject_id",
+                "aggregation": "lastNotNull"
+            }
         }
     },
     "subject": {

--- a/tests/parsers/oneToMany.json
+++ b/tests/parsers/oneToMany.json
@@ -1,9 +1,11 @@
 {
-    "name": "sampleOneToMany",
-    "description": "One to Many example",
-    "tables": {
-        "observation": {
-            "kind": "oneToMany"
+    "adtl": {
+        "name": "sampleOneToMany",
+        "description": "One to Many example",
+        "tables": {
+            "observation": {
+                "kind": "oneToMany"
+            }
         }
     },
     "observation": [
@@ -13,7 +15,7 @@
             },
             "name": "headache",
             "is_present": true,
-            "#if": {
+            "if": {
                 "headache_cmyn": 1
             }
         },
@@ -23,7 +25,7 @@
             },
             "name": "cough",
             "is_present": true,
-            "#if": {
+            "if": {
                 "cough_cmyn": 1
             }
         },
@@ -33,7 +35,7 @@
             },
             "name": "dyspnea",
             "is_present": true,
-            "#if": {
+            "if": {
                 "dyspnea_cmyn": 1
             }
         }

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -242,7 +242,7 @@ def test_invalid_combined_type():
 
 
 def test_validate_spec():
-    with pytest.raises(ValueError, match="Specification requires key"):
+    with pytest.raises(ValueError, match="Specification header requires key"):
         ps = parser.Parser(dict())
 
 
@@ -319,14 +319,14 @@ def test_validate():
         (({}, {}), {}),
         (
             (
-                {"a": {"#ref": "map"}, "b": 2},
+                {"a": {"ref": "map"}, "b": 2},
                 {"map": {"values": {"1": True, "2": False}}},
             ),
             {"a": {"values": {"1": True, "2": False}}, "b": 2},
         ),
         (
             (
-                {"a": [{"#ref": "map"}, {"x": 4}]},
+                {"a": [{"ref": "map"}, {"x": 4}]},
                 {"map": {"values": {"1": True, "2": False}}},
             ),
             {"a": [{"values": {"1": True, "2": False}}, {"x": 4}]},
@@ -340,5 +340,5 @@ def test_expand_refs(source, expected):
 def test_reference_expansion():
     ps_noref = parser.Parser(TEST_PARSERS_PATH / "groupBy.json")
     ps_ref = parser.Parser(TEST_PARSERS_PATH / "groupBy-defs.json")
-    del ps_ref.spec["#defs"]
+    del ps_ref.spec["adtl"]["defs"]
     assert ps_ref.spec == ps_noref.spec


### PR DESCRIPTION
TOML does not support # in bare keys, removing them for simplicity.
Also moves metadata (name/description/tables/defs) into an adtl
header to free up top level namespace for table assignments.
