### PR TITLE
Change excludeWhen allowed values, fixes #24

### DIFF
--- a/adtl/__init__.py
+++ b/adtl/__init__.py
@@ -182,18 +182,20 @@ def get_combined_type(row: StrDict, rule: StrDict):
         except StopIteration:
             return None
     elif combined_type == "list":
-        excludeWhen = rule.get("excludeWhen", ...)  # use ... as sentinel
-        if excludeWhen not in [None, False, ...] and not isinstance(excludeWhen, list):
+        excludeWhen = rule.get("excludeWhen")
+        if excludeWhen not in [None, "false-like", "none"] and not isinstance(
+            excludeWhen, list
+        ):
             raise ValueError(
-                "excludeWhen rule should be null, false, or a list of values"
+                "excludeWhen rule should be 'none', 'false-like', or a list of values"
             )
 
         values = [get_value(row, r) for r in rules]
-        if excludeWhen == ...:
-            return values
         if excludeWhen is None:
+            return values
+        if excludeWhen == "none":
             return [v for v in values if v is not None]
-        elif excludeWhen is False:
+        elif excludeWhen == "false-like":
             return [v for v in values if v]
         else:
             return [v for v in values if v not in excludeWhen]

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -253,7 +253,7 @@ such as hashing the field.
   }
   ```
 
-  **excludeWhen**: List fields can have an optional *excludeWhen* key which can either be a list of values or `null` or `false`. When it is `null` we drop the null values (None in Python) or it can be `false` in which case falsy values are excluded (empty lists, boolean False, 0). Alternatively a list of values to be excluded can be provided.
+  **excludeWhen**: List fields can have an optional *excludeWhen* key which can either be a list of values or `none` or `false-like`. When it is `none` we drop the null values (None in Python) or it can be `false-like` in which case false-like values (`bool(x) == False` in Python) are excluded (empty lists, boolean False, 0). Alternatively a list of values to be excluded can be provided.
 
   If *excludeWhen* is not set, no exclusions take place and all values are returned as-is.
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -103,7 +103,7 @@ female,001,dataset-2020-03-23,GBR,2022-01-11,2020-06-08
         (
             (
                 {"modliv": "1", "mildliver": "3"},
-                {**RULE_COMBINED_TYPE_LIST_PATTERN, "excludeWhen": None},
+                {**RULE_COMBINED_TYPE_LIST_PATTERN, "excludeWhen": "none"},
             ),
             [True],
         ),
@@ -213,8 +213,8 @@ def test_invalid_operand_parse_if():
     "rowrule,expected",
     [
         ((ROW_CONCISE, RULE_EXCLUDE), [0, 2]),
-        ((ROW_CONCISE, {**RULE_EXCLUDE, "excludeWhen": False}), [2]),
-        ((ROW_CONCISE, {**RULE_EXCLUDE, "excludeWhen": None}), [0, 2]),
+        ((ROW_CONCISE, {**RULE_EXCLUDE, "excludeWhen": "false-like"}), [2]),
+        ((ROW_CONCISE, {**RULE_EXCLUDE, "excludeWhen": "none"}), [0, 2]),
         ((ROW_CONCISE, {**RULE_EXCLUDE, "excludeWhen": [2]}), [0]),
     ],
 )
@@ -224,7 +224,8 @@ def test_list_exclude(rowrule, expected):
 
 def test_invalid_list_exclude():
     with pytest.raises(
-        ValueError, match="excludeWhen rule should be null, false, or a list of values"
+        ValueError,
+        match="excludeWhen rule should be 'none', 'false-like', or a list of values",
     ):
         parser.get_combined_type(
             {"modliv": 1, "mildliv": 2},


### PR DESCRIPTION
If excludeWhen is not set, no exclusions take place and all values are
returned as-is.  excludeWhen = null and excludeWhen not set can be
differentiated in JSON but not in TOML, as TOML does not support nil
values. This changes excludeWhen allowed values to 'false-like', 'none'
or a list of values.
