### PR TITLE
Sort output fields for reproducibility

### DIFF
--- a/adtl/__init__.py
+++ b/adtl/__init__.py
@@ -267,10 +267,10 @@ class Parser:
                     f"Parser specification missing required '{table}' element"
                 )
             if self.tables[table].get("kind") != "oneToMany":
-                self.fieldnames[table] = list(self.spec[table].keys())
+                self.fieldnames[table] = sorted(list(self.spec[table].keys()))
             else:
-                self.fieldnames[table] = list(
-                    set(sum([list(m.keys()) for m in self.spec[table]], []))
+                self.fieldnames[table] = sorted(
+                    list(set(sum([list(m.keys()) for m in self.spec[table]], [])))
                 )
         for table in self.tables:
             aggregation = self.tables[table].get("aggregation")

--- a/tests/__snapshots__/test_parser.ambr
+++ b/tests/__snapshots__/test_parser.ambr
@@ -1,9 +1,9 @@
 # serializer version: 1
 # name: test_parse_write_buffer
   '''
-  sex_at_birth,subject_id,dataset_id,country_iso3,enrolment_date,admission_date
-  male,007,dataset-2020-03-23,GBR,2020-05-06,2020-06-08
-  female,001,dataset-2020-03-23,GBR,2022-01-11,2020-06-08
+  admission_date,country_iso3,dataset_id,enrolment_date,sex_at_birth,subject_id
+  2020-06-08,GBR,dataset-2020-03-23,2020-05-06,male,007
+  2020-06-08,GBR,dataset-2020-03-23,2022-01-11,female,001
   
   '''
 # ---


### PR DESCRIPTION
Dictionaries do not have a defined key order, sorting ensures
runs are reproducible.
