### PR TITLE
Fix oneToMany if bug, cast into numeric types when possible

### DIFF
--- a/adtl/__init__.py
+++ b/adtl/__init__.py
@@ -334,9 +334,15 @@ class Parser:
             if self.tables[table].get("kind") != "oneToMany":
                 self.fieldnames[table] = sorted(list(self.spec[table].keys()))
             else:
-                self.fieldnames[table] = sorted(
+                self.fieldnames[table] = list(
+                    self.tables[table].get("common", {}).keys()
+                ) + sorted(
                     list(set(sum([list(m.keys()) for m in self.spec[table]], [])))
                 )
+                if commonMappings := self.tables[table].get("common", {}):
+                    for match in self.spec[table]:
+                        match.update(commonMappings)
+
         for table in self.tables:
             aggregation = self.tables[table].get("aggregation")
             group_field = self.tables[table].get("groupBy")

--- a/adtl/__init__.py
+++ b/adtl/__init__.py
@@ -35,7 +35,16 @@ def get_value(row: StrDict, rule: Rule) -> Any:
     value = get_value_unhashed(row, rule)
     if isinstance(rule, dict) and rule.get("sensitive") and value is not None:
         return hash_sensitive(value)
-    else:
+    if not isinstance(value, str):
+        return value
+    try:
+        return int(value)
+    except ValueError:
+        try:
+            return float(value)
+        except ValueError:
+            return value
+    except TypeError:
         return value
 
 

--- a/adtl/__init__.py
+++ b/adtl/__init__.py
@@ -355,10 +355,16 @@ class Parser:
                     self.data[table][group_key][attr] = value
         elif kind == "oneToMany":
             for match in self.spec[table]:
-                rowIf = match.pop("if", None)
-                if rowIf is None or parse_if(row, rowIf):
+                if "if" not in match:
+                    raise ValueError(
+                        f"oneToMany tables must have a 'if' key setting condition for row to be emitted: {match!r}"
+                    )
+                if parse_if(row, match["if"]):
                     self.data[table].append(
-                        {attr: get_value(row, match[attr]) for attr in match}
+                        {
+                            attr: get_value(row, match[attr])
+                            for attr in set(match.keys()) - {"if"}
+                        }
                     )
         elif kind == "constant":  # only one row
             self.data[table] = [self.spec[table]]

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -33,6 +33,8 @@ adtl parser files.
     attribute to the last non-null value in the grouped dataset.
   * *schema* (optional): Specifies JSON schema to use for validation,
     can be a relative path, or a URL
+  * *common* (optional): Specifies common mappings that are applied to every if-block
+    in a *kind*=*oneToMany* table.
 
 * **defs**: Definitions that can be referred to elsewhere in the schema
 

--- a/tests/__snapshots__/test_parser.ambr
+++ b/tests/__snapshots__/test_parser.ambr
@@ -2,17 +2,17 @@
 # name: test_parse_write_buffer
   '''
   admission_date,country_iso3,dataset_id,enrolment_date,sex_at_birth,subject_id
-  2020-06-08,GBR,dataset-2020-03-23,2020-05-06,male,007
-  2020-06-08,GBR,dataset-2020-03-23,2022-01-11,female,001
+  2020-06-08,GBR,dataset-2020-03-23,2020-05-06,male,S007
+  2020-06-08,GBR,dataset-2020-03-23,2022-01-11,female,S001
   
   '''
 # ---
 # name: test_validation
   '''
   adtl_valid,adtl_error,admission_date,country_iso3,dataset_id,enrolment_date,sex_at_birth,subject_id
-  True,,2020-06-08,GBR,dataset-2020-03-23,2020-05-06,male,007
-  False,"data must contain ['subject_id', 'country_iso3', 'enrolment_date', 'sex_at_birth'] properties",8/6/2022,GBR,dataset-2020-03-23,2022-01-11,,001
-  False,data.admission_date must be date,8/6/2020,GBR,dataset-2020-03-23,2020-05-06,male,009
+  True,,2020-06-08,GBR,dataset-2020-03-23,2020-05-06,male,S007
+  False,"data must contain ['subject_id', 'country_iso3', 'enrolment_date', 'sex_at_birth'] properties",8/6/2022,GBR,dataset-2020-03-23,2022-01-11,,S001
+  False,data.admission_date must be date,8/6/2020,GBR,dataset-2020-03-23,2020-05-06,male,S009
   
   '''
 # ---

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -76,25 +76,25 @@ ONE_MANY_OUTPUT = [
 ]
 
 SOURCE_GROUPBY = [
-    {"sex": "1", "subjid": "007", "dsstdat": "2020-05-06", "hostdat": "2020-06-08"},
-    {"sex": "2", "subjid": "001", "dsstdat": "2022-01-11", "hostdat": "2020-06-08"},
+    {"sex": "1", "subjid": "S007", "dsstdat": "2020-05-06", "hostdat": "2020-06-08"},
+    {"sex": "2", "subjid": "S001", "dsstdat": "2022-01-11", "hostdat": "2020-06-08"},
 ]
 
 SOURCE_GROUPBY_INVALID = [
-    {"sex": "1", "subjid": "007", "dsstdat": "2020-05-06", "hostdat": "2020-06-08"},
-    {"sex": "5", "subjid": "001", "dsstdat": "2022-01-11", "hostdat": "8/6/2022"},
-    {"sex": "1", "subjid": "009", "dsstdat": "2020-05-06", "hostdat": "8/6/2020"},
+    {"sex": "1", "subjid": "S007", "dsstdat": "2020-05-06", "hostdat": "2020-06-08"},
+    {"sex": "5", "subjid": "S001", "dsstdat": "2022-01-11", "hostdat": "8/6/2022"},
+    {"sex": "1", "subjid": "S009", "dsstdat": "2020-05-06", "hostdat": "8/6/2020"},
 ]
 
 BUFFER_GROUPBY = """
 sex_at_birth,subject_id,dataset_id,country_iso3,enrolment_date,admission_date
-male,007,dataset-2020-03-23,GBR,2020-05-06,2020-06-08
-female,001,dataset-2020-03-23,GBR,2022-01-11,2020-06-08
+male,S007,dataset-2020-03-23,GBR,2020-05-06,2020-06-08
+female,S001,dataset-2020-03-23,GBR,2022-01-11,2020-06-08
 """
 
 SOURCE_APPLY_PRESENT = [
     {
-        "subjid": "007",
+        "subjid": "S007",
         "brthdtc": "1996-02-24",
         "dsstdat": "2023-02-24",
         "age": "22",
@@ -103,11 +103,11 @@ SOURCE_APPLY_PRESENT = [
     }
 ]
 APPLY_PRESENT_OUTPUT = [
-    {"subject_id": "007", "age": pytest.approx(27.0, 0.001), "icu_admitted": True}
+    {"subject_id": "S007", "age": pytest.approx(27.0, 0.001), "icu_admitted": True}
 ]
 SOURCE_APPLY_ABSENT = [
     {
-        "subjid": "007",
+        "subjid": "S007",
         "brthdtc": "",
         "dsstdat": "2023-02-24",
         "age": "22",
@@ -115,14 +115,14 @@ SOURCE_APPLY_ABSENT = [
         "icu_hostdat": "",
     }
 ]
-APPLY_ABSENT_OUTPUT = [{"subject_id": "007", "age": 22.0, "icu_admitted": False}]
+APPLY_ABSENT_OUTPUT = [{"subject_id": "S007", "age": 22.0, "icu_admitted": False}]
 
 
 @pytest.mark.parametrize(
     "row_rule,expected",
     [
         (({"diabetes_mhyn": "1"}, RULE_SINGLE_FIELD_WITH_MAPPING), True),
-        (({"diabetes_mhyn": "1"}, RULE_SINGLE_FIELD), "1"),
+        (({"diabetes_mhyn": "1"}, RULE_SINGLE_FIELD), 1),
         (({}, "CONST"), "CONST"),
         (({"modliv": "1", "mildliver": "0"}, RULE_COMBINED_TYPE_ANY), True),
         (({"modliv": "1", "mildliver": "0"}, RULE_COMBINED_TYPE_ALL), False),
@@ -142,15 +142,15 @@ APPLY_ABSENT_OUTPUT = [{"subject_id": "007", "age": 22.0, "icu_admitted": False}
             ({"modliv": "1", "mildliver": "3"}, RULE_COMBINED_TYPE_LIST_PATTERN),
             [True, None],
         ),
-        (({"id": "1"}, RULE_NON_SENSITIVE), "1"),
+        (({"id": "1"}, RULE_NON_SENSITIVE), 1),
         (
             ({"id": "1"}, RULE_SENSITIVE),
             "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b",
         ),
-        (({"first": "1", "second": ""}, RULE_COMBINED_FIRST_NON_NULL), "1"),
-        (({"first": "1", "second": "2"}, RULE_COMBINED_FIRST_NON_NULL), "1"),
-        (({"first": "2", "second": "1"}, RULE_COMBINED_FIRST_NON_NULL), "2"),
-        (({"first": "", "second": "3"}, RULE_COMBINED_FIRST_NON_NULL), "3"),
+        (({"first": "1", "second": ""}, RULE_COMBINED_FIRST_NON_NULL), 1),
+        (({"first": "1", "second": "2"}, RULE_COMBINED_FIRST_NON_NULL), 1),
+        (({"first": "2", "second": "1"}, RULE_COMBINED_FIRST_NON_NULL), 2),
+        (({"first": "", "second": "3"}, RULE_COMBINED_FIRST_NON_NULL), 3),
         ((ROW_CONDITIONAL, RULE_CONDITIONAL_OK), "2022-01-01"),
         ((ROW_CONDITIONAL, RULE_CONDITIONAL_FAIL), None),
         ((ROW_UNIT_MONTH, RULE_UNIT), 1.5),


### PR DESCRIPTION
Attempt to cast strings into integers or floats if possible, and return cast values instead of strings.

This is a **breaking change** as previously all get_value() results that were not a container type were either booleans or strings.

Also fixes a bug in if parsing for oneToMany tables
