### PR TITLE
Add getFloat to remove chars from numerical fields

### DIFF
--- a/adtl/transformations.py
+++ b/adtl/transformations.py
@@ -8,6 +8,19 @@ def isNotNull(value):
     return value not in [None, ""]
 
 
+def getFloat(value):
+    if not value:
+        return None
+
+    if '"' in value or " " in value:
+        value = value.strip('"').replace(" ", "")
+
+    try:
+        return float(value)
+    except ValueError:
+        return value
+
+
 def yearsElapsed(birthdate, currentdate):
     if birthdate in [None, ""] or currentdate in [None, ""]:
         return None

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -54,3 +54,11 @@ def test_startDate(test_startdate_start, test_startdate_duration, expected):
     assert (
         transform.startDate(test_startdate_start, test_startdate_duration) == expected
     )
+
+
+@pytest.mark.parametrize(
+    "badfloat, expected",
+    [('" - 11 ', -11.0), ('"3"', 3.0), ("3,4", "3,4")],
+)
+def test_getFloat(badfloat, expected):
+    assert transform.getFloat(badfloat) == expected


### PR DESCRIPTION
Strips additional whitespace and quotes to allow float conversion.

Reduces number of 'data.value must be float' errors