### PR TITLE
Add endDate, auto-if behaviour in oneToMany table

### DIFF
--- a/adtl/transformations.py
+++ b/adtl/transformations.py
@@ -60,3 +60,17 @@ def startDate(enddate, duration):
     sd = ed - timedelta(days=duration)
 
     return sd.strftime("%Y-%m-%d")
+
+
+def endDate(startdate, duration):
+    """
+    Retuns the end date in ISO format, given the start date and the duration.
+    """
+    if startdate in [None, ""] or duration in [None, ""]:
+        return None
+
+    sd = datetime.strptime(startdate, "%Y-%m-%d")
+
+    ed = sd + timedelta(days=duration)
+
+    return ed.strftime("%Y-%m-%d")

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -138,6 +138,31 @@ if.all = [  # in TOML this is a nested key, like { "if": { "all": [ ... ] } }
 ]
 ```
 
+The **oneToMany** table has default conditional behaviour so that rows are only shown
+if the row is not empty, and contains values which can be mapped correctly if maps are
+provided. For example, an observation recording the presence/absence of vomiting should only
+be shown if values map to True/False:
+
+```ini
+[[table]]
+  name = "vomiting_nausea"
+  is_present = { field = "Admission Symptoms.Vomiting", values = {1 = True, 0 = False} } # values = ['0', 'Unknown', '1', 'UNKNOWN', '']
+  # if.any = [{ "Admission Symptoms.Vomiting" = '1'}, { "Admission Symptoms.Vomiting" = '0'}] <- rule assumed by adtl
+```
+If a different/more specific conditional statement is required, e.g. if a row should only be displayed
+based on the condition of a different field, this behaviour can be overridden by writing an
+if condition into the parser; note that this will *stop any automated generation*, you should
+specify all conditions under which the row should be displayed, for example:
+
+```ini
+[[observation]]
+  name = "transfer_from_other_facility"
+  phase = "study"
+  date = { field = "rpt_date" }
+  if = { rpt_date = { "!=" = "" } } # This is dependent on a date rather than an is_present field, so requires specifying.
+  is_present = true
+```
+
 ### Field with unit
 
 Often values need to be normalised to a particular unit.

--- a/tests/parsers/oneToMany-missingIf.toml
+++ b/tests/parsers/oneToMany-missingIf.toml
@@ -4,6 +4,7 @@
 
   [adtl.tables.observation]
     kind = "oneToMany"
+    schema = "../schemas/observation_defaultif.schema.json"
 
 [adtl.defs]
   "Y/N/NK" = { values = { 1 = true, 2 = false } }

--- a/tests/parsers/oneToMany-missingIf.toml
+++ b/tests/parsers/oneToMany-missingIf.toml
@@ -1,0 +1,41 @@
+[adtl]
+  name = "sampleOneToMany - missingIf"
+  description = "One to Many example where if statements are removed"
+
+  [adtl.tables.observation]
+    kind = "oneToMany"
+
+[adtl.defs]
+  "Y/N/NK" = { values = { 1 = true, 2 = false } }
+
+[[observation]]
+  name = "headache"
+  phase = "admission"
+  date = { field = "dt" }
+  is_present = { field = "headache_v2", ref = "Y/N/NK" }
+
+[[observation]]
+  name = "oxygen_saturation"
+  phase = "admission"
+  date = { field = "dt" }
+  value = { field = "oxy_vsorres", description = "Oxygen saturation" }
+
+[[observation]]
+  name = "cough"
+  date = { field = "dt" }
+  phase = "admission"
+  is_present = { field = "cough_ceoccur_v2", ref = "Y/N/NK" }
+
+[[observation]]
+  name = "pao2_sample_type"
+  phase = "study"
+  date = { field = "dt" }
+  text = { field = "pao2_lbspec", values = { 1 = "Arterial", 3 = "Capillary" } }
+
+[[observation]]
+  name = "history_of_fever"
+  phase = "followup"
+  date = { field = "dt_{n}" }
+  is_present = { field = "flw2_fever_{n}", values = { 0 = false, 1 = true } }
+  # if.any = [ { "flw2_fever_{n}" = 1 }, { "flw2_fever_{n}" = 0 } ]
+  for.n.range = [1, 2]

--- a/tests/schemas/observation_defaultif.schema.json
+++ b/tests/schemas/observation_defaultif.schema.json
@@ -1,0 +1,73 @@
+{
+    "$schema": "https://json-schema.org/draft-07/schema",
+    "$id": "https://raw.githubusercontent.com/globaldothealth/isaric/main/schemas/dev/observation.schema.json",
+    "title": "Study observation",
+    "description": "Observations relating to a visit, including vital signs and symptoms",
+    "required": [
+        "phase",
+        "date",
+        "name"
+    ],
+    "oneOf": [
+        {
+            "required": [
+                "text"
+            ]
+        },
+        {
+            "required": [
+                "value"
+            ]
+        },
+        {
+            "required": [
+                "is_present"
+            ]
+        }
+    ],
+    "properties": {
+        "phase": {
+            "enum": [
+                "pre-admission",
+                "admission",
+                "study",
+                "followup"
+            ],
+            "description": "Phase of study"
+        },
+        "date": {
+            "type": "string",
+            "format": "date",
+            "description": "Date of observation, or end date of observation period"
+        },
+        "value": {
+            "type": "number",
+            "description": "Value of the observation"
+        },
+        "text": {
+            "type": "string",
+            "description": "Value of the observation (text)"
+        },
+        "is_present": {
+            "type": "boolean",
+            "description": "Whether the observation denotes presence (*true*) or absence (*false*)"
+        },
+        "name": {
+            "enum": [
+                "cough",
+                "headache",
+                "oxygen_saturation",
+                "pao2_sample_type",
+                "history_of_fever"
+            ],
+            "description": "Observation name"
+        }
+    },
+    "dependencies": {
+        "start_date": {
+            "required": [
+                "duration_type"
+            ]
+        }
+    }
+}

--- a/tests/sources/oneToManyIf-missing.csv
+++ b/tests/sources/oneToManyIf-missing.csv
@@ -1,0 +1,2 @@
+dt,dt_1,dt_2,headache_v2,oxy_vsorres,cough_ceoccur_v2,pao2_lbspec,flw2_fever_1,flw2_fever_2
+2022-02-05,2022-02-06,2022-02-07,3,,1,4,,0

--- a/tests/sources/oneToManyIf.csv
+++ b/tests/sources/oneToManyIf.csv
@@ -1,0 +1,2 @@
+dt,dt_1,dt_2,headache_v2,oxy_vsorres,cough_ceoccur_v2,pao2_lbspec,flw2_fever_1,flw2_fever_2
+2022-02-05,2022-02-06,2022-02-07,2,87,1,3,1,0

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -94,6 +94,60 @@ ONE_MANY_OUTPUT = [
     {"date": "2022-02-05", "name": "cough", "is_present": True},
 ]
 
+ONE_MANY_IF_OUTPUT = [
+    {
+        "date": "2022-02-05",
+        "name": "headache",
+        "phase": "admission",
+        "is_present": False,
+    },
+    {
+        "date": "2022-02-05",
+        "name": "oxygen_saturation",
+        "phase": "admission",
+        "value": 87.0,
+    },
+    {
+        "date": "2022-02-05",
+        "name": "cough",
+        "phase": "admission",
+        "is_present": True,
+    },
+    {
+        "date": "2022-02-05",
+        "name": "pao2_sample_type",
+        "phase": "study",
+        "text": "Capillary",
+    },
+    {
+        "date": "2022-02-06",
+        "name": "history_of_fever",
+        "phase": "followup",
+        "is_present": True,
+    },
+    {
+        "date": "2022-02-07",
+        "name": "history_of_fever",
+        "phase": "followup",
+        "is_present": False,
+    },
+]
+
+ONE_MANY_IF_MISSINGDATA_OUTPUT = [
+    {
+        "date": "2022-02-05",
+        "name": "cough",
+        "phase": "admission",
+        "is_present": True,
+    },
+    {
+        "date": "2022-02-07",
+        "name": "history_of_fever",
+        "phase": "followup",
+        "is_present": False,
+    },
+]
+
 SOURCE_GROUPBY = [
     {"sex": "1", "subjid": "S007", "dsstdat": "2020-05-06", "hostdat": "2020-06-08"},
     {"sex": "2", "subjid": "S001", "dsstdat": "2022-01-11", "hostdat": "2020-06-08"},
@@ -220,6 +274,8 @@ APPLY_OBSERVATIONS_OUTPUT = [
         (({"first": "1", "second": "2"}, RULE_COMBINED_FIRST_NON_NULL), 1),
         (({"first": "2", "second": "1"}, RULE_COMBINED_FIRST_NON_NULL), 2),
         (({"first": "", "second": "3"}, RULE_COMBINED_FIRST_NON_NULL), 3),
+        (({"first": False, "second": True}, RULE_COMBINED_FIRST_NON_NULL), False),
+        (({"first": "", "second": False}, RULE_COMBINED_FIRST_NON_NULL), False),
         ((ROW_CONDITIONAL, RULE_CONDITIONAL_OK), "2022-01-01"),
         ((ROW_CONDITIONAL, RULE_CONDITIONAL_FAIL), None),
         ((ROW_UNIT_MONTH, RULE_UNIT), 1.5),
@@ -297,6 +353,22 @@ def test_one_to_many():
     )
     assert actual_one_many_output_rows == ONE_MANY_OUTPUT
     assert actual_one_many_output_csv == ONE_MANY_OUTPUT
+
+
+def test_one_to_many_correct_if_behaviour():
+    actual_row = list(
+        parser.Parser(TEST_PARSERS_PATH / "oneToMany-missingIf.toml")
+        .parse(TEST_SOURCES_PATH / "oneToManyIf.csv")
+        .read_table("observation")
+    )
+    actual_row_missing = list(
+        parser.Parser(TEST_PARSERS_PATH / "oneToMany-missingIf.toml")
+        .parse(TEST_SOURCES_PATH / "oneToManyIf-missing.csv")
+        .read_table("observation")
+    )
+
+    assert actual_row == ONE_MANY_IF_OUTPUT
+    assert actual_row_missing == ONE_MANY_IF_MISSINGDATA_OUTPUT
 
 
 # test exceptions

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -100,36 +100,42 @@ ONE_MANY_IF_OUTPUT = [
         "name": "headache",
         "phase": "admission",
         "is_present": False,
+        "adtl_valid": True,
     },
     {
         "date": "2022-02-05",
         "name": "oxygen_saturation",
         "phase": "admission",
         "value": 87.0,
+        "adtl_valid": True,
     },
     {
         "date": "2022-02-05",
         "name": "cough",
         "phase": "admission",
         "is_present": True,
+        "adtl_valid": True,
     },
     {
         "date": "2022-02-05",
         "name": "pao2_sample_type",
         "phase": "study",
         "text": "Capillary",
+        "adtl_valid": True,
     },
     {
         "date": "2022-02-06",
         "name": "history_of_fever",
         "phase": "followup",
         "is_present": True,
+        "adtl_valid": True,
     },
     {
         "date": "2022-02-07",
         "name": "history_of_fever",
         "phase": "followup",
         "is_present": False,
+        "adtl_valid": True,
     },
 ]
 
@@ -139,12 +145,14 @@ ONE_MANY_IF_MISSINGDATA_OUTPUT = [
         "name": "cough",
         "phase": "admission",
         "is_present": True,
+        "adtl_valid": True,
     },
     {
         "date": "2022-02-07",
         "name": "history_of_fever",
         "phase": "followup",
         "is_present": False,
+        "adtl_valid": True,
     },
 ]
 
@@ -355,6 +363,7 @@ def test_one_to_many():
     assert actual_one_many_output_csv == ONE_MANY_OUTPUT
 
 
+# HERE
 def test_one_to_many_correct_if_behaviour():
     actual_row = list(
         parser.Parser(TEST_PARSERS_PATH / "oneToMany-missingIf.toml")

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -1,9 +1,5 @@
-import sys
-import json
-from pathlib import Path
 import pytest
 
-import adtl as parser
 import adtl.transformations as transform
 
 
@@ -54,6 +50,18 @@ def test_startDate(test_startdate_start, test_startdate_duration, expected):
     assert (
         transform.startDate(test_startdate_start, test_startdate_duration) == expected
     )
+
+
+@pytest.mark.parametrize(
+    "test_enddate_start, test_enddate_duration, expected",
+    [
+        ("2023-01-24", 10, "2023-02-03"),
+        ("", "2023-02-22", None),
+        (None, "2023-02-22", None),
+    ],
+)
+def test_endDate(test_enddate_start, test_enddate_duration, expected):
+    assert transform.endDate(test_enddate_start, test_enddate_duration) == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
* Added endDate to calculate dates given a start date and duration (for Washington dataset)

* Bug-fixed firstNonNull which wasn't recognising 'False' as a valid non-Null value

* Add default `if' behaviour for the oneToMany table, removing requirement for if statements in the parser if you only want to (1) not show empty strings, or (2) have a set of values mapped and don't want to show those outside that mapping.