### PR TITLE
Patch for endDate

### DIFF
--- a/adtl/transformations.py
+++ b/adtl/transformations.py
@@ -71,6 +71,8 @@ def endDate(startdate, duration):
 
     sd = datetime.strptime(startdate, "%Y-%m-%d")
 
+    duration = float(duration)
+
     ed = sd + timedelta(days=duration)
 
     return ed.strftime("%Y-%m-%d")


### PR DESCRIPTION
fixes problem where duration is being read in as a string rather than a float