### PR TITLE
Allow constant strings in apply parameters

### DIFF
--- a/adtl/__init__.py
+++ b/adtl/__init__.py
@@ -73,8 +73,11 @@ def get_value_unhashed(row: StrDict, rule: Rule, ctx: Context = None) -> Any:
             transformation = rule["apply"]["function"]
             if "params" in rule["apply"]:
                 params = [
-                    row[rule["apply"]["params"][i]]
-                    if isinstance(rule["apply"]["params"][i], str)
+                    row[rule["apply"]["params"][i][1:]]
+                    if (
+                        isinstance(rule["apply"]["params"][i], str)
+                        and rule["apply"]["params"][i].startswith("$")
+                    )
                     else rule["apply"]["params"][i]
                     for i in range(len(rule["apply"]["params"]))
                 ]

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -149,6 +149,7 @@ be shown if values map to True/False:
   is_present = { field = "Admission Symptoms.Vomiting", values = {1 = True, 0 = False} } # values = ['0', 'Unknown', '1', 'UNKNOWN', '']
   # if.any = [{ "Admission Symptoms.Vomiting" = '1'}, { "Admission Symptoms.Vomiting" = '0'}] <- rule assumed by adtl
 ```
+
 If a different/more specific conditional statement is required, e.g. if a row should only be displayed
 based on the condition of a different field, this behaviour can be overridden by writing an
 if condition into the parser; note that this will *stop any automated generation*, you should
@@ -265,6 +266,9 @@ other than the source field which need to be parsed into the transformation
 function must be listed as `params`, in the same order as they should be
 passed to the transformation function.
 
+If the parameter is a field attribute value from the source data, the field name
+should be prefixed with a `$` to distinguish it from constant strings.
+
 ```ini
 [[table]]
   field = "icu_admitted"
@@ -272,7 +276,7 @@ passed to the transformation function.
 
 [[table]]
   field = "brthdtc"
-  apply = { function = "yearsElapsed", params = ["dsstdat"] }
+  apply = { function = "yearsElapsed", params = ["$dsstdat"] }
 
 ```
 

--- a/tests/parsers/apply.toml
+++ b/tests/parsers/apply.toml
@@ -18,7 +18,7 @@
 
     [[subject.age.fields]]
       field = "brthdtc"
-      apply = { function = "yearsElapsed", params = ["dsstdat"] }
+      apply = { function = "yearsElapsed", params = ["$dsstdat"] }
 
     [[subject.age.fields]]
       field = "age"


### PR DESCRIPTION
Previously, constant strings were interpreted as field names when
using apply. This changes the behaviour to require $ prefix to
indicate the following token is a field name.
