### PR TITLE
BREAKING CHANGE: any and all return None if all values are None

### DIFF
--- a/adtl/__init__.py
+++ b/adtl/__init__.py
@@ -229,9 +229,17 @@ def get_combined_type(row: StrDict, rule: StrDict, ctx: Context = None):
         else:
             rules.append(r)
     if combined_type == "all":
-        return all(get_value(row, r, ctx) for r in rules)
+        values = [get_value(row, r, ctx) for r in rules]
+        if all(v is None for v in values):
+            return None
+        else:
+            return all(values)
     elif combined_type == "any":
-        return any(get_value(row, r, ctx) for r in rules)
+        values = [get_value(row, r, ctx) for r in rules]
+        if all(v is None for v in values):
+            return None
+        else:
+            return any(values)
     elif combined_type == "firstNonNull":
         try:
             return next(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["adtl"]
 
 [project]
 name = "adtl"
-version = "0.3.0"
+version = "0.4.0"
 description = "Another data transformation language"
 authors = [{name = "Abhishek Dasgupta", email = "abhishek.dasgupta@dtc.ox.ac.uk"}]
 license = {file = "LICENSE"}

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -276,7 +276,7 @@ APPLY_OBSERVATIONS_OUTPUT = [
         (({"diabetes_mhyn": "1"}, RULE_SINGLE_FIELD), 1),
         (({}, "CONST"), "CONST"),
         (({"modliv": "1", "mildliver": "0"}, RULE_COMBINED_TYPE_ANY), True),
-        (({"modliv": "", "mildliver": ""}, RULE_COMBINED_TYPE_ANY), False),
+        (({"modliv": "", "mildliver": ""}, RULE_COMBINED_TYPE_ANY), None),
         (({"modliv": "1", "mildliver": "0"}, RULE_COMBINED_TYPE_ALL), False),
         (({"modliv": "1", "mildliver": "0"}, RULE_COMBINED_TYPE_LIST), [True, False]),
         (


### PR DESCRIPTION
Prior to this change, combinedType = any/all would return False if
all the values in the list were None. In most cases, datasets have
all values None when data is missing, and in that case, assuming
negative when data is missing is inconsistent with the mapping for
single fields.

In addition, for the clinical applications that are being used,
value mappings are better imagined as open-world (absence of a
statement does not imply falsity) rather than closed-world, where
the absence of a statement means it is false. As an example, for
medication mappings, it is possible we have missed out a medication
in the antibiotics list, so the absence does not imply that a
patient did not receive that category of medication, in this case,
antibiotics. In general, we are more certain that something happened
(patient was given a certain medication), assuming no entry errors,
rather than something did not (patient did not receive antibiotics).
