### PR TITLE
Skip fields

### DIFF
--- a/adtl/__init__.py
+++ b/adtl/__init__.py
@@ -422,18 +422,10 @@ def read_definition(file: Path) -> Dict[str, Any]:
 def skip_field(row, rule, ctx: Context = None):
     "Returns True if the field is missing and allowed to be skipped"
     # made no difference
-    if "can_skip" in rule:
-        if rule["can_skip"]:
-            if rule["field"] not in row:
-                return True
-            else:
-                return False
-    if ctx and ctx.get("skip_pattern"):
-        if ctx.get("skip_pattern").match(rule["field"]):
-            if rule["field"] not in row:
-                return True
-            else:
-                return False
+    if rule.get("can_skip"):
+        return rule["field"] not in row
+    if ctx and ctx.get("skip_pattern") and ctx.get("skip_pattern").match(rule["field"]):
+        return rule["field"] not in row
     return False
 
 

--- a/adtl/__init__.py
+++ b/adtl/__init__.py
@@ -145,7 +145,9 @@ def matching_fields(fields: List[str], pattern: str) -> List[str]:
     return [f for f in fields if compiled_pattern.match(f)]
 
 
-def parse_if(row: StrDict, rule: StrDict, ctx: Callable = None, can_skip=False) -> bool:
+def parse_if(
+    row: StrDict, rule: StrDict, ctx: Callable[[str], dict] = None, can_skip=False
+) -> bool:
     "Parse conditional statements and return a boolean"
 
     n_keys = len(rule.keys())
@@ -419,9 +421,8 @@ def read_definition(file: Path) -> Dict[str, Any]:
         raise ValueError(f"Unsupported file format: {file}")
 
 
-def skip_field(row, rule, ctx: Context = None):
+def skip_field(row: StrDict, rule: StrDict, ctx: Context = None):
     "Returns True if the field is missing and allowed to be skipped"
-    # made no difference
     if rule.get("can_skip"):
         return rule["field"] not in row
     if ctx and ctx.get("skip_pattern") and ctx.get("skip_pattern").match(rule["field"]):

--- a/adtl/__init__.py
+++ b/adtl/__init__.py
@@ -151,7 +151,6 @@ def parse_if(
     "Parse conditional statements and return a boolean"
 
     n_keys = len(rule.keys())
-    # assert n_keys == 1
     assert n_keys == 1 or n_keys == 2
     if n_keys == 2:
         assert "can_skip" in rule
@@ -166,7 +165,7 @@ def parse_if(
     try:
         attr_value = row[key]
     except KeyError as e:
-        if can_skip == True:
+        if can_skip is True:
             return False
         elif ctx:
             if skip_field(row, {"field": key}, ctx(key)):
@@ -599,7 +598,7 @@ class Parser:
             ], f"Invalid combinedType: {rule[option]['combinedType']}"
             rules = rule[option]["fields"]
 
-            def create_if_rule(rule):  # better, but not faster
+            def create_if_rule(rule):
                 field = rule["field"]
                 values = rule.get("values", [])
                 can_skip = rule.get("can_skip", False)

--- a/schemas/dev.schema.json
+++ b/schemas/dev.schema.json
@@ -27,6 +27,10 @@
               "type": "string",
               "description": "This is only used with combinedType, specifies a regular expression matching multiple fields"
             },
+            "fieldOption": {
+              "type": "string",
+              "description": "Corresponding field name in source file, can be skipped if not present in data"
+            },
             "sensitive": {
               "type": "boolean",
               "description": "Indicates to the parser whether the field is sensitive. Usually a sensitive field is hashed or encrypted before storing in the database.",

--- a/schemas/dev.schema.json
+++ b/schemas/dev.schema.json
@@ -86,9 +86,8 @@
               }
             },
             "can_skip": {
-              "type": "boolean",
-              "description": "Indicates to the parser whether the field can be skipped without throwing an error if missing in the data.",
-              "default": false
+              "const": true,
+              "description": "Indicates to the parser whether the field can be skipped without throwing an error if missing in the data."
             }
           }
         }

--- a/schemas/dev.schema.json
+++ b/schemas/dev.schema.json
@@ -27,10 +27,6 @@
               "type": "string",
               "description": "This is only used with combinedType, specifies a regular expression matching multiple fields"
             },
-            "fieldOption": {
-              "type": "string",
-              "description": "Corresponding field name in source file, can be skipped if not present in data"
-            },
             "sensitive": {
               "type": "boolean",
               "description": "Indicates to the parser whether the field is sensitive. Usually a sensitive field is hashed or encrypted before storing in the database.",
@@ -88,6 +84,11 @@
                   ]
                 }
               }
+            },
+            "can_skip": {
+              "type": "boolean",
+              "description": "Indicates to the parser whether the field can be skipped without throwing an error if missing in the data.",
+              "default": false
             }
           }
         }

--- a/tests/__snapshots__/test_parser.ambr
+++ b/tests/__snapshots__/test_parser.ambr
@@ -25,17 +25,17 @@
 # ---
 # name: test_skip_field_pattern_absent
   '''
-  adtl_valid,adtl_error,cough,epoch,followup_cough,id,text
-  False,data.epoch must be date,1,11/01/1999,,1,Lorem ipsum
-  False,data.epoch must be date,0,19/12/2022,,2,example
+  adtl_valid,adtl_error,cough,epoch,followup_cough,headache,id,text
+  False,data.epoch must be date,1,11/01/1999,,,1,Lorem ipsum
+  False,data.epoch must be date,0,19/12/2022,,,2,example
   
   '''
 # ---
 # name: test_skip_field_pattern_present
   '''
-  adtl_valid,adtl_error,cough,epoch,followup_cough,id,text
-  False,data.epoch must be date,1,11/01/1999,0,1,Lorem ipsum
-  False,data.epoch must be date,0,19/12/2022,1,2,example
+  adtl_valid,adtl_error,cough,epoch,followup_cough,headache,id,text
+  False,data.epoch must be date,1,11/01/1999,0,3,1,Lorem ipsum
+  False,data.epoch must be date,0,19/12/2022,1,0,2,example
   
   '''
 # ---

--- a/tests/__snapshots__/test_parser.ambr
+++ b/tests/__snapshots__/test_parser.ambr
@@ -23,6 +23,22 @@
   
   '''
 # ---
+# name: test_skip_field_pattern_absent
+  '''
+  adtl_valid,adtl_error,cough,epoch,followup_cough,id,text
+  False,data.epoch must be date,1,11/01/1999,,1,Lorem ipsum
+  False,data.epoch must be date,0,19/12/2022,,2,example
+  
+  '''
+# ---
+# name: test_skip_field_pattern_present
+  '''
+  adtl_valid,adtl_error,cough,epoch,followup_cough,id,text
+  False,data.epoch must be date,1,11/01/1999,0,1,Lorem ipsum
+  False,data.epoch must be date,0,19/12/2022,1,2,example
+  
+  '''
+# ---
 # name: test_validation
   '''
   adtl_valid,adtl_error,admission_date,country_iso3,dataset_id,enrolment_date,ethnicity,sex_at_birth,subject_id

--- a/tests/parsers/oneToMany-missingIf.toml
+++ b/tests/parsers/oneToMany-missingIf.toml
@@ -1,6 +1,7 @@
 [adtl]
   name = "sampleOneToMany - missingIf"
   description = "One to Many example where if statements are removed"
+  skipFieldPattern = "flw3.*"
 
   [adtl.tables.observation]
     kind = "oneToMany"
@@ -47,3 +48,15 @@
   is_present = { field = "flw2_fever_{n}", values = { 0 = false, 1 = true } }
   # if.any = [ { "flw2_fever_{n}" = 1 }, { "flw2_fever_{n}" = 0 } ]
   for.n.range = [1, 2]
+
+[[observation]]
+  name = "fatigue_malaise"
+  phase = "followup"
+  date = { field = "dt" }
+  is_present = { field = "flw3_fatigue", description = "Fatigue", values = { 1 = true, 0 = false } }
+
+[[observation]]
+  name = "severe_dehydration"
+  phase = "admission"
+  date = { field = "dt" }
+  is_present = { field = "dehydration_vsorres", description = "Severe dehydration:", ref = "Y/N/NK", "can_skip" = true }

--- a/tests/parsers/skip_field.json
+++ b/tests/parsers/skip_field.json
@@ -1,0 +1,30 @@
+{
+  "adtl": {
+    "name": "allow-skip-field-pattern",
+    "description": "Tests skipping missing fields",
+    "skipFieldPattern": "flw.*",
+    "tables": {
+      "table": {
+        "kind": "oneToOne",
+        "schema": "../schemas/epoch-data.schema.json"
+      }
+    }
+  },
+  "table": {
+    "id": {
+      "field": "Entry_ID"
+    },
+    "epoch": {
+      "field": "Epoch"
+    },
+    "text": {
+      "field": "Text"
+    },
+    "cough": {
+      "field": "cough"
+    },
+    "followup_cough": {
+      "field": "flw_cough"
+    }
+  }
+}

--- a/tests/parsers/skip_field.json
+++ b/tests/parsers/skip_field.json
@@ -25,6 +25,10 @@
     },
     "followup_cough": {
       "field": "flw_cough"
+    },
+    "headache": {
+      "field": "headache",
+      "can_skip": true
     }
   }
 }

--- a/tests/schemas/epoch-data.schema.json
+++ b/tests/schemas/epoch-data.schema.json
@@ -21,6 +21,12 @@
     },
     "text": {
       "description": "Text field"
+    },
+    "cough": {
+      "description": "Standard cough field"
+    },
+    "followup_cough": {
+      "description": "Follow-up cough field"
     }
   }
 }

--- a/tests/schemas/observation_defaultif.schema.json
+++ b/tests/schemas/observation_defaultif.schema.json
@@ -58,7 +58,9 @@
                 "headache",
                 "oxygen_saturation",
                 "pao2_sample_type",
-                "history_of_fever"
+                "history_of_fever",
+                "fatigue_malaise",
+                "severe_dehydration"
             ],
             "description": "Observation name"
         }

--- a/tests/sources/oneToManyIf.csv
+++ b/tests/sources/oneToManyIf.csv
@@ -1,2 +1,2 @@
-dt,dt_1,dt_2,headache_v2,oxy_vsorres,cough_ceoccur_v2,dry_cough_ceoccur_v2,wet_cough_ceoccur_v2,pao2_lbspec,flw2_fever_1,flw2_fever_2
-2022-02-05,2022-02-06,2022-02-07,2,87,3,1,2,3,1,0
+dt,dt_1,dt_2,headache_v2,oxy_vsorres,cough_ceoccur_v2,dry_cough_ceoccur_v2,wet_cough_ceoccur_v2,pao2_lbspec,flw2_fever_1,flw2_fever_2,flw3_fatigue,dehydration_vsorres
+2022-02-05,2022-02-06,2022-02-07,2,87,3,1,2,3,1,0,1,2

--- a/tests/sources/skip_field_absent.csv
+++ b/tests/sources/skip_field_absent.csv
@@ -1,0 +1,3 @@
+Entry_ID,Epoch,Text,cough
+1,11/01/1999,Lorem ipsum,1
+2,19/12/2022,example,0

--- a/tests/sources/skip_field_present.csv
+++ b/tests/sources/skip_field_present.csv
@@ -1,0 +1,3 @@
+Entry_ID,Epoch,Text,cough,flw_cough
+1,11/01/1999,Lorem ipsum,1,0
+2,19/12/2022,example,0,1

--- a/tests/sources/skip_field_present.csv
+++ b/tests/sources/skip_field_present.csv
@@ -1,3 +1,3 @@
-Entry_ID,Epoch,Text,cough,flw_cough
-1,11/01/1999,Lorem ipsum,1,0
-2,19/12/2022,example,0,1
+Entry_ID,Epoch,Text,cough,flw_cough,headache
+1,11/01/1999,Lorem ipsum,1,0,3
+2,19/12/2022,example,0,1,0

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -279,6 +279,23 @@ APPLY_OBSERVATIONS_OUTPUT = [
     },
 ]
 
+RULE_FIELD_OPTION = {
+    "field": "aidshiv_mhyn",
+    "values": {"1": True, "0": False},
+    "can_skip": True,
+}
+
+# OBSERVATION_RULE_FIELD_OPTION = {
+#     "name": "bleeding",
+#     "phase": "admission",
+#     "date": "2023-05-18",
+#     "is_present": {
+#         "field": "bleed_ceterm_v2",
+#         "values": {"1": True, "0": False},
+#         "can_skip": True,
+#     },
+# }
+
 
 @pytest.mark.parametrize(
     "row_rule,expected",
@@ -350,6 +367,9 @@ APPLY_OBSERVATIONS_OUTPUT = [
             unordered(["Lopinavir/Ritonvir", "Interferon alpha"]),
         ),
         (({"first": "", "second": ""}, RULE_COMBINED_FIRST_NON_NULL), None),
+        (({"aidshiv": "1"}, RULE_FIELD_OPTION), None),
+        (({"aidshiv_mhyn": "1"}, RULE_FIELD_OPTION), True),
+        (({"aidshiv_mhyn": "2"}, RULE_FIELD_OPTION), None),
     ],
 )
 def test_get_value(row_rule, expected):
@@ -405,7 +425,6 @@ def test_one_to_many():
     assert actual_one_many_output_csv == ONE_MANY_OUTPUT
 
 
-# HERE
 def test_one_to_many_correct_if_behaviour():
     actual_row = list(
         parser.Parser(TEST_PARSERS_PATH / "oneToMany-missingIf.toml")
@@ -781,3 +800,21 @@ def test_apply_in_observations_table():
     )
 
     assert apply_observations_output == APPLY_OBSERVATIONS_OUTPUT
+
+
+def test_skip_field_pattern_present(snapshot):
+    transformed_csv_data = (
+        parser.Parser(TEST_PARSERS_PATH / "skip_field.json")
+        .parse(TEST_SOURCES_PATH / "skip_field_present.csv")
+        .write_csv("table")
+    )
+    assert transformed_csv_data == snapshot
+
+
+def test_skip_field_pattern_absent(snapshot):
+    transformed_csv_data = (
+        parser.Parser(TEST_PARSERS_PATH / "skip_field.json")
+        .parse(TEST_SOURCES_PATH / "skip_field_absent.csv")
+        .write_csv("table")
+    )
+    assert transformed_csv_data == snapshot


### PR DESCRIPTION
This PR allows certain fields, or field patterns, to be skipped if not present in the data, to use when a single study has multiple datasets with a varying amount of data entry.