### PR TITLE
Add exception tests

### DIFF
--- a/adtl/__init__.py
+++ b/adtl/__init__.py
@@ -167,14 +167,13 @@ def parse_if(
         return all(parse_if(row, r, ctx, can_skip) for r in rule[key])
     try:
         attr_value = row[key]
-    except KeyError as e:
+    except KeyError:
         if can_skip is True:
             return False
         elif ctx:
             if skip_field(row, {"field": key}, ctx(key)):
                 return False
-        else:
-            raise e
+        raise
 
     if isinstance(rule[key], dict):
         cmp = next(iter(rule[key]))

--- a/adtl/__init__.py
+++ b/adtl/__init__.py
@@ -599,6 +599,8 @@ class Parser:
                 "firstNonNull",
                 "set",
                 "list",
+                "min",
+                "max",
             ], f"Invalid combinedType: {rule[option]['combinedType']}"
             rules = rule[option]["fields"]
 
@@ -616,8 +618,10 @@ class Parser:
                 elif can_skip:
                     if_condition[field] = {"!=": ""}
                     if_condition["can_skip"] = True
+                    if_condition = [if_condition]
                 else:
                     if_condition[field] = {"!=": ""}
+                    if_condition = [if_condition]
 
                 return if_condition
 

--- a/adtl/transformations.py
+++ b/adtl/transformations.py
@@ -19,21 +19,31 @@ def textIfNotNull(field, return_val):
     return return_val if field not in [None, ""] else None
 
 
-def getFloat(value):
+def getFloat(value, set_decimal=None, separator=None):
+    """
+    In cases where the decimal seperators is not a . you can
+    use set_decimal. Similarly, if thousand seperators are
+    used they can be specified.
+    """
+
     if not value:
         return None
 
     if '"' in value or " " in value:
         value = value.strip('"').replace(" ", "")
 
-    # handle comma decimal separator
-    value_int, _, fraction = value.partition(",")
-    if "." in fraction:  # comma was being used as a thousands separator
-        value = value_int + fraction
-    else:
-        # replace full stops as they may be used for thousands separator, first
-        # then use full stop as decimal separator
-        value = value.replace(".", "").replace(",", ".")
+    if set_decimal:
+        # handle comma decimal separator
+        # partition always splits on last instance so copes if decimal == separator
+        value_int, _, fraction = value.partition(set_decimal)
+        value = value_int + "." + fraction
+
+    if separator:
+        if separator in value and separator != ".":
+            value = value.replace(separator, "")
+        elif separator in value_int:
+            value = value_int.replace(separator, "") + "." + fraction
+
     try:
         return float(value)
     except ValueError:

--- a/tests/sources/oneToManyIf-missingError.csv
+++ b/tests/sources/oneToManyIf-missingError.csv
@@ -1,0 +1,2 @@
+dt,dt_1,dt_2,oxy_vsorres,cough_ceoccur_v2,dry_cough_ceoccur_v2,wet_cough_ceoccur_v2,pao2_lbspec,flw2_fever_1,flw2_fever_2
+2022-02-05,2022-02-06,2022-02-07,,1,3,2,4,,0

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -556,6 +556,13 @@ def test_invalid_operand_parse_if():
         )
 
 
+def test_missing_key_parse_if():
+    with pytest.raises(KeyError, match="headache_v2"):
+        parser.Parser(TEST_PARSERS_PATH / "oneToMany-missingIf.toml").parse(
+            TEST_SOURCES_PATH / "oneToManyIf-missingError.csv"
+        )
+
+
 @pytest.mark.parametrize(
     "rowrule,expected",
     [

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -67,16 +67,19 @@ def test_endDate(test_enddate_start, test_enddate_duration, expected):
 @pytest.mark.parametrize(
     "badfloat, expected",
     [
-        ('" - 11 ', -11.0),
-        ('"3"', 3.0),
-        ("3,4", 3.4),
-        ("1,234.5", 1234.5),
-        ("1.234,5", 1234.5),
-        ("1.567.923,66", 1567923.66),
+        (('" - 11 ', None, None), -11.0),
+        (('"3"', None, None), 3.0),
+        (("-3.", None, None), -3),
+        (('" 3.4 "', None, None), 3.4),
+        (("3,4", ",", None), 3.4),
+        (("1,234.5", None, ","), 1234.5),
+        (("1.234,5", ",", "."), 1234.5),
+        (("1.567.923,66", ",", "."), 1567923.66),
     ],
 )
 def test_getFloat(badfloat, expected):
-    assert transform.getFloat(badfloat) == expected
+    badfloat, dec, sep = badfloat
+    assert transform.getFloat(badfloat, set_decimal=dec, separator=sep) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -67,6 +67,8 @@ def test_endDate(test_enddate_start, test_enddate_duration, expected):
 @pytest.mark.parametrize(
     "badfloat, expected",
     [
+        ((None, None, None), None),
+        ((False, None, None), None),
         (('" - 11 ', None, None), -11.0),
         (('"3"', None, None), 3.0),
         (("-3.", None, None), -3),
@@ -75,6 +77,7 @@ def test_endDate(test_enddate_start, test_enddate_duration, expected):
         (("1,234.5", None, ","), 1234.5),
         (("1.234,5", ",", "."), 1234.5),
         (("1.567.923,66", ",", "."), 1567923.66),
+        (('" -1+1"', None, None), "-1+1"),
     ],
 )
 def test_getFloat(badfloat, expected):
@@ -90,6 +93,7 @@ def test_getFloat(badfloat, expected):
         ("", "13", "", None),
         ("2020", "05", "04", "2020-05-04"),
         ("1999", "12", "44", None),
+        ("2020", "May", "04", None),
     ],
 )
 def test_makeDate(year, month, day, expected):
@@ -99,9 +103,11 @@ def test_makeDate(year, month, day, expected):
 @pytest.mark.parametrize(
     "date,time_seconds,date_format,tzname,expected",
     [
+        ("", "41400", "%d/%m/%Y", "UTC", None),
         ("04/05/2020", "41400", "%d/%m/%Y", "UTC", "2020-05-04T11:30:00+00:00"),
         ("04/05/2020", "", "%d/%m/%Y", "UTC", "2020-05-04"),
         ("04/05/2020", "", "%m/%d/%Y", "UTC", "2020-04-05"),
+        ("04/05/2020", "", "%Y-%m-%d", "UTC", None),
         ("05/06/2020", "86399", "%d/%m/%Y", "UTC", "2020-06-05T23:59:00+00:00"),
         ("05/06/2020", "86399", "%d/%m/%Y", "Asia/Tokyo", "2020-06-05T23:59:00+09:00"),
     ],


### PR DESCRIPTION
Changes getFloat behaviour to force explicit definition of the decimal/thousand separator to stop unwanted conversation of normal floats (e.g. prior behaviour converted "3.4" -> 34)

Expands various tests & fixes a few bugs