### PR TITLE
Fixes behaviour where for loops combine with apply

### DIFF
--- a/adtl/__init__.py
+++ b/adtl/__init__.py
@@ -311,11 +311,13 @@ def expand_for(spec: List[StrDict]) -> List[StrDict]:
     out = []
 
     def replace_val(
-        item: Union[str, Dict[str, Any]], replace: Dict[str, Any]
+        item: Union[str, float, Dict[str, Any]], replace: Dict[str, Any]
     ) -> Dict[str, Any]:
         block = {}
         if isinstance(item, str):
             return item.format(**replace)
+        elif isinstance(item, (float, int)):
+            return item
         for k, v in item.items():
             if not isinstance(k, str):
                 block[k] = v

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -925,6 +925,67 @@ EXPANDED_FOR_PATTERN_MULTI_VAR = [
     },
 ]
 
+FOR_PATTERN_APPLY = [
+    {
+        "name": "cough",
+        "phase": "followup",
+        "date": {"field": "flw2_survey_date_{n}"},
+        "start_date": {
+            "field": "flw2_survey_date_{n}",
+            "apply": {
+                "function": "startDate",
+                "params": [
+                    7,
+                ],
+            },
+        },
+        "for": {"n": {"range": [1, 2]}},
+        "is_present": {
+            "field": "flw2_pers_cough_dry_{n}",
+            "values": {"0": False, "1": True},
+        },
+    }
+]
+
+EXPANDED_FOR_PATTERN_APPLY = [
+    {
+        "name": "cough",
+        "phase": "followup",
+        "date": {"field": "flw2_survey_date_1"},
+        "start_date": {
+            "field": "flw2_survey_date_1",
+            "apply": {
+                "function": "startDate",
+                "params": [
+                    7,
+                ],
+            },
+        },
+        "is_present": {
+            "field": "flw2_pers_cough_dry_1",
+            "values": {"0": False, "1": True},
+        },
+    },
+    {
+        "name": "cough",
+        "phase": "followup",
+        "date": {"field": "flw2_survey_date_2"},
+        "start_date": {
+            "field": "flw2_survey_date_2",
+            "apply": {
+                "function": "startDate",
+                "params": [
+                    7,
+                ],
+            },
+        },
+        "is_present": {
+            "field": "flw2_pers_cough_dry_2",
+            "values": {"0": False, "1": True},
+        },
+    },
+]
+
 
 @pytest.mark.parametrize(
     "source,expected",
@@ -932,6 +993,7 @@ EXPANDED_FOR_PATTERN_MULTI_VAR = [
         (FOR_PATTERN, EXPANDED_FOR_PATTERN),
         (FOR_PATTERN_ANY, EXPANDED_FOR_PATTERN_ANY),
         (FOR_PATTERN_MULTI_VAR, EXPANDED_FOR_PATTERN_MULTI_VAR),
+        (FOR_PATTERN_APPLY, EXPANDED_FOR_PATTERN_APPLY),
     ],
 )
 def test_expand_for(source, expected):


### PR DESCRIPTION
Fixes where apply was being used with a parameter list of ints/floats, the for loop expansion crashed as it only expected str/dict options.