### PR TITLE
Allow 'getFloat' to scrape a number from a string with other text

### DIFF
--- a/adtl/transformations.py
+++ b/adtl/transformations.py
@@ -9,6 +9,7 @@ except ImportError:
     from backports import zoneinfo  # noqa
 
 import pint
+import re
 
 
 def isNotNull(value):
@@ -43,6 +44,9 @@ def getFloat(value, set_decimal=None, separator=None):
             value = value.replace(separator, "")
         elif separator in value_int:
             value = value_int.replace(separator, "") + "." + fraction
+
+    values = [float(d) for d in re.findall(r"[-+]?\d*\.?\d+", value)]
+    value = values[0] if len(values) == 1 else value
 
     try:
         return float(value)

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -78,6 +78,7 @@ def test_endDate(test_enddate_start, test_enddate_duration, expected):
         (("1.234,5", ",", "."), 1234.5),
         (("1.567.923,66", ",", "."), 1567923.66),
         (('" -1+1"', None, None), "-1+1"),
+        ((" -3 - Moderate Sedation", None, None), -3),
     ],
 )
 def test_getFloat(badfloat, expected):


### PR DESCRIPTION
E.g. sometimes scales like sedation scales are filled in as a mix of numbers and '-3 moderate sedation' etc. Want to be able to scrape out the value in these cases.