### PR TITLE
allow date formats to be specifed in yearsElapsed function

### DIFF
--- a/adtl/transformations.py
+++ b/adtl/transformations.py
@@ -54,12 +54,12 @@ def getFloat(value, set_decimal=None, separator=None):
         return value
 
 
-def yearsElapsed(birthdate, currentdate):
+def yearsElapsed(birthdate, currentdate, bd_format="%Y-%m-%d", cd_format="%Y-%m-%d"):
     if birthdate in [None, ""] or currentdate in [None, ""]:
         return None
 
-    bd = datetime.strptime(birthdate, "%Y-%m-%d")
-    cd = datetime.strptime(currentdate, "%Y-%m-%d")
+    bd = datetime.strptime(birthdate, bd_format)
+    cd = datetime.strptime(currentdate, cd_format)
 
     days = cd - bd
     return pint.Quantity(days.days, "days").to("years").m

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -25,6 +25,20 @@ def test_yearsElasped(test_date_birth, test_date_current, expected):
 
 
 @pytest.mark.parametrize(
+    "test_date_birth, test_date_current, bd_format, cd_format, expected",
+    [
+        ("1950", "2023-01-01 00:00", "%Y", "%Y-%m-%d %H:%M", 73),
+    ],
+)
+def test_yearsElasped_format(
+    test_date_birth, test_date_current, bd_format, cd_format, expected
+):
+    assert transform.yearsElapsed(
+        test_date_birth, test_date_current, bd_format, cd_format
+    ) == pytest.approx(expected, 0.001)
+
+
+@pytest.mark.parametrize(
     "test_duration_start, test_duration_current, expected",
     [
         ("2023-02-01", "2023-03-05", 32),


### PR DESCRIPTION
Dates aren't formatted before going into apply functions - this allows yearsElapsed to have the input (particularly where the parameter is a field) date format specified.