### PR TITLE
Add model choice

### DIFF
--- a/docs/autoparser/examples/cli_example.md
+++ b/docs/autoparser/examples/cli_example.md
@@ -7,6 +7,9 @@ are run from the root of the `autoparser` package.
 
 Note: As a reminder, you will need an API key for OpenAI or Google. This example uses the OpenAI LLM.
 
+You can use Gemini by using the `--llm_provider gemini` flag in the first two steps, or specify which model you
+wish to use from either OpenAI or Gemini with the `llm_model` option.
+
 ## Generate a data dictionary
 In this example, we will generate a data dictionary with descriptions already added in one step. The CLI command follows this syntax:
 

--- a/docs/autoparser/examples/cli_example.md
+++ b/docs/autoparser/examples/cli_example.md
@@ -12,7 +12,7 @@ In this example, we will generate a data dictionary with descriptions already ad
 
 
 ```bash
-adtl-autoparser create-dict data language [-d] [-k api_key] [-l llm_choice] [-c config_file] [-o output_name]
+adtl-autoparser create-dict data language [-d] [-k api_key] [-l llm_provider] [-m llm_model] [-c config_file] [-o output_name]
 ```
 where the `-d` flag is used to request the LLM-generated descriptions. For the
 `animal_data.csv` data we will run this command to generate a data dictionary
@@ -27,7 +27,7 @@ This creates an `animals_dd.csv` data dictionary to use in the next step.
 The next step is to create an intermediate CSV for you to inspect, mapping the fields and values in the raw data to the target schema. This is the CLI syntax:
 
 ```bash
-adtl-autoparser create-mapping dictionary schema language api_key [-l llm_choice] [-c config_file] [-o output_name]
+adtl-autoparser create-mapping dictionary schema language api_key [-l llm_provider] [-m llm_model] [-c config_file] [-o output_name]
 ```
 so we can run
 ```bash

--- a/docs/autoparser/examples/example.ipynb
+++ b/docs/autoparser/examples/example.ipynb
@@ -17,9 +17,12 @@
     "You should add yours to your environment, as described [here](https://help.openai.com/en/articles/5112595-best-practices-for-api-key-safety).\n",
     "This example uses the OpenAI API; edit the `API_KEY` line below to match the name you gave yours.\n",
     "\n",
-    "If you would prefer to use Gemini, use the `llm` variable in functions where the api key is used, e.g.\n",
+    "If you would prefer to use Gemini, use the `llm_provider` argument in functions where the api key is used, e.g.\n",
     "\n",
-    "`writer.generate_descriptions(\"fr\", data_dict, key=API_KEY, llm='gemini')`"
+    "`writer.generate_descriptions(\"fr\", data_dict, key=API_KEY, llm_provider='gemini')`\n",
+    "\n",
+    "You can also specify which model from either OpenAI or Gemini you wish to use, with the `llm_model` argument. Your model choice should support Structured Outputs (for [OpenAI](https://platform.openai.com/docs/guides/structured-outputs#supported-models)) or Controlled Generation (for [Gemini](https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/control-generated-output)).\n",
+    "The model should be provided as a string recognised by the respective api, e.g. `llm_model = \"gpt-4o-mini\"` (the default model when OpenAI is selected as the provider)."
    ]
   },
   {

--- a/docs/autoparser/getting_started/index.md
+++ b/docs/autoparser/getting_started/index.md
@@ -24,10 +24,13 @@ options available.
 AutoParser relies on LLMs to automatically map raw data fields to a target schema.
 In order to use this tool, you will need an API key for either [OpenAI](https://platform.openai.com/docs/quickstart/create-and-export-an-api-key)
 or Google's [Gemini](https://aistudio.google.com/apikey).
-AutoParser will use either OpenAI's `gpt-4o-mini`, or Google's `gemini-1.5-flash`.
+You can select which model to use, or keep to the defaults which are OpenAI's `gpt-4o-mini`,
+or Google's `gemini-1.5-flash`. Your model choice should support Structured Outputs (for [OpenAI](https://platform.openai.com/docs/guides/structured-outputs#supported-models)) or Controlled Generation (for [Gemini](https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/control-generated-output)). Please be aware that more high-powered models like OpenAI's
+'O' series and Gemini 2.0 will cost more per API call.
 
 The LLM should *never* see your raw data; only the data dictionary which contains
-column headers, and text descriptions of what each field shoud contain.
+column headers, text descriptions of what each field contains, and a list of frequently
+occuring values if present.
 
 ### Supported file formats
 Autoparser supports CSV and XLSX formats for raw data and data dictionary files, and either

--- a/docs/autoparser/usage/parser_generation.md
+++ b/docs/autoparser/usage/parser_generation.md
@@ -30,9 +30,11 @@ format should be filled using data from the `StatusCas` field in the raw data. T
 column indicated that all instances of `décédé` in the raw data should be mapped to `dead`
 in the converted file, and `vivant` should map to `alive`.
 
-&#x26a0;&#xfe0f; **LLM's are prone to errors and hallucinations**. These intermediate mappings
+:::{warning}
+**LLM's are prone to errors and hallucinations**. These intermediate mappings
 should be manually curated, as the LLM may generate incorrect matches for either
 the field, or the values within that field.
+:::
 
 ## Generate TOML
 

--- a/docs/autoparser/usage/parser_generation.md
+++ b/docs/autoparser/usage/parser_generation.md
@@ -1,10 +1,9 @@
 # Write a Data Parser
 
-AutoParser assumes the use of Global.Health's [adtl](https://github.com/globaldothealth/adtl)
-package to transform your source data into a standardised format. To do this, adtl requires a
-[TOML](https://toml.io/en/) specification file which describes how raw data should be
-converted into the new format, on a field-by-field basis. Every unique data file format
-(i.e. unique sets of fields and data types) should have a corresponding parser file.
+ADTL requires a [TOML](https://toml.io/en/) specification file which describes how raw
+data should be converted into a new format, on a field-by-field basis. Every unique data
+file format (i.e. unique sets of fields and data types) should have a corresponding
+parser file.
 
 AutoParser exists to semi-automate the process of writing new parser files. This requires
 a data dictionary (which can be created if it does not already exist, see '[Create Data dictionary](data_dict)'),
@@ -31,8 +30,8 @@ format should be filled using data from the `StatusCas` field in the raw data. T
 column indicated that all instances of `décédé` in the raw data should be mapped to `dead`
 in the converted file, and `vivant` should map to `alive`.
 
-These intermediate mappings should be manually curated, as they are generated using an
-LLM which may be prone to errors and hallucinations, generating incorrect matches for either
+&#x26a0;&#xfe0f; **LLM's are prone to errors and hallucinations**. These intermediate mappings
+should be manually curated, as the LLM may generate incorrect matches for either
 the field, or the values within that field.
 
 ## Generate TOML

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,12 @@ easy to use library in Python for basic data transformations, which are
 specified in either a JSON or TOML file. It is not meant to be a comprehensive, and
 adtl can be used as a step within a larger data processing pipeline.
 
+## AutoParser
+
+AutoParser provides a semi-automated method for writing the transformation files required
+by ADTL, by using LLMs for field and value mapping. This reduces the need for users to
+write JSON/TOML specification files from scratch by hand.
+
 ```{toctree}
 ---
 caption: Getting started

--- a/src/adtl/autoparser/dict_writer.py
+++ b/src/adtl/autoparser/dict_writer.py
@@ -294,7 +294,8 @@ def generate_descriptions(
     data_dict: pd.DataFrame | str,
     language: str,
     key: str | None = None,
-    llm: str | None = "openai",
+    llm_provider: str | None = "openai",
+    llm_model: str | None = None,
     config: Path | None = None,
 ) -> pd.DataFrame:
     """
@@ -312,8 +313,12 @@ def generate_descriptions(
         Language the column headers are in (e.g. french, spanish).
     key
         OpenAI API key.
-    llm
-        LLM API to call (currently only OpenAI is supported)
+    llm_provider
+        LLM API to call (currently OpenAI & Google Gemini are supported)
+    llm_model
+        Name of the LLM model to use (must support Structured Outputs for OpenAI, or the
+        equivalent responseSchema for Gemini). If not provided, the default for each
+        provider will be used.
     config
         Path to the configuration file to use if not using the default configuration
 
@@ -323,7 +328,9 @@ def generate_descriptions(
         Data dictionary with descriptions added
     """
 
-    dd = DictWriter(config=config).generate_descriptions(language, data_dict, key, llm)
+    dd = DictWriter(config=config).generate_descriptions(
+        language, data_dict, key, llm_provider, llm_model
+    )
 
     return dd
 
@@ -346,7 +353,10 @@ def main(argv=None):
     parser.add_argument(
         "-k", "--api-key", help="OpenAI API key to generate descriptions"
     )
-    parser.add_argument("-l", "--llm", help="LLM API to use", default="openai")
+    parser.add_argument("-l", "--llm-provider", help="LLM API to use", default="openai")
+    parser.add_argument(
+        "-m", "--llm-model", help="Select a specific model from the llm provider"
+    )
     parser.add_argument(
         "-c",
         "--config",
@@ -365,7 +375,12 @@ def main(argv=None):
     df = create_dict(args.data, args.config)
     if args.descriptions:
         df = generate_descriptions(
-            df, args.language, args.api_key, args.llm, args.config
+            df,
+            args.language,
+            args.api_key,
+            args.llm_provider,
+            args.llm_model,
+            args.config,
         )
 
     df.to_csv(f"{args.output}.csv", index=False)

--- a/src/adtl/autoparser/dict_writer.py
+++ b/src/adtl/autoparser/dict_writer.py
@@ -37,6 +37,13 @@ class DictWriter:
     ----------
     config
         The path to the configuration file to use if not using the default configuration
+    llm_provider
+        The LLM API to use (currently only OpenAI & Google Gemini are supported)
+    llm_model
+        The name of the LLM model to use (must support Structured Outputs for OpenAI, or
+        the equivalent responseSchema for Gemini)
+    api_key
+        API key corresponsing to the chosen LLM provider/model
     """
 
     def __init__(
@@ -57,8 +64,8 @@ class DictWriter:
         except KeyError:
             raise ValueError("'max_common_count' not found in config file.")
 
-        if llm_provider and api_key:
-            self.model = setup_llm(llm_provider, api_key, model=llm_model)
+        if (llm_provider or llm_model) and api_key:
+            self.model = setup_llm(api_key, provider=llm_provider, model=llm_model)
         else:
             self.model = None
 
@@ -231,7 +238,7 @@ class DictWriter:
         df = load_data_dict(self.config, data_dict)
 
         if not self.model:
-            self.model = setup_llm(llm_provider, key, model=llm_model)
+            self.model = setup_llm(key, provider=llm_provider, model=llm_model)
 
         headers = df.source_field
 

--- a/src/adtl/autoparser/dict_writer.py
+++ b/src/adtl/autoparser/dict_writer.py
@@ -357,12 +357,17 @@ def main(argv=None):
         help="Use an LLM to generate descriptions from file headers",
         action="store_true",
     )
+    parser.add_argument("-k", "--api-key", help="LLM API key to generate descriptions")
     parser.add_argument(
-        "-k", "--api-key", help="OpenAI API key to generate descriptions"
+        "-l",
+        "--llm-provider",
+        help="LLM API to use, either 'openai' or 'gemini'",
+        default="openai",
     )
-    parser.add_argument("-l", "--llm-provider", help="LLM API to use", default="openai")
     parser.add_argument(
-        "-m", "--llm-model", help="Select a specific model from the llm provider"
+        "-m",
+        "--llm-model",
+        help="Select a specific model from the llm provider, e.g. 'gpt-4o-mini'",
     )
     parser.add_argument(
         "-c",

--- a/src/adtl/autoparser/dict_writer.py
+++ b/src/adtl/autoparser/dict_writer.py
@@ -42,7 +42,8 @@ class DictWriter:
     def __init__(
         self,
         config: Path | str | None = None,
-        llm: str | None = None,
+        llm_provider: str | None = None,
+        llm_model: str | None = None,
         api_key: str | None = None,
     ):
         if isinstance(config, str):
@@ -56,8 +57,8 @@ class DictWriter:
         except KeyError:
             raise ValueError("'max_common_count' not found in config file.")
 
-        if llm and api_key:
-            self.model = setup_llm(llm, api_key)
+        if llm_provider and api_key:
+            self.model = setup_llm(llm_provider, api_key, model=llm_model)
         else:
             self.model = None
 
@@ -188,7 +189,8 @@ class DictWriter:
         language: str,
         data_dict: pd.DataFrame | str | None = None,
         key: str | None = None,
-        llm: str | None = "openai",
+        llm_provider: str = "openai",
+        llm_model: str | None = None,
     ) -> pd.DataFrame:
         """
         Generate descriptions for the columns in the dataset.
@@ -206,8 +208,12 @@ class DictWriter:
             has already been created using `create_dict()`.
         key
             OpenAI API key.
-        llm
-            LLM API to call (currently only OpenAI is supported)
+        llm_provider
+            LLM API to call (currently only OpenAI & Google Gemini is supported)
+        llm_model
+            Name of the LLM model to use (must support Structured Outputs for OpenAI, or
+            the equivalent responseSchema for Gemini). If not provided, the default for
+            each provider will be used.
 
         Returns
         -------
@@ -225,7 +231,7 @@ class DictWriter:
         df = load_data_dict(self.config, data_dict)
 
         if not self.model:
-            self.model = setup_llm(llm, key)
+            self.model = setup_llm(llm_provider, key, model=llm_model)
 
         headers = df.source_field
 

--- a/src/adtl/autoparser/language_models/gemini.py
+++ b/src/adtl/autoparser/language_models/gemini.py
@@ -16,13 +16,13 @@ class GeminiLanguageModel(LLMBase):
         self.client = gemini.GenerativeModel(model)
         self.model = model
 
-        if self.model not in self.valid_models:
+        if self.model not in self.valid_models():
             raise ValueError(
                 f"Unsupported Gemini model. Must be one of {self.valid_models}."
             )
 
-    @property
-    def valid_models(self):
+    @classmethod
+    def valid_models(cls):
         return ["gemini-1.5-flash", "gemini-1.5-pro", "gemini-2.0-flash"]
 
     def get_definitions(self, headers: list[str], language: str) -> dict[str, str]:

--- a/src/adtl/autoparser/language_models/gemini.py
+++ b/src/adtl/autoparser/language_models/gemini.py
@@ -16,6 +16,15 @@ class GeminiLanguageModel(LLMBase):
         self.client = gemini.GenerativeModel(model)
         self.model = model
 
+        if self.model not in self.valid_models:
+            raise ValueError(
+                f"Unsupported Gemini model. Must be one of {self.valid_models}."
+            )
+
+    @property
+    def valid_models(self):
+        return ["gemini-1.5-flash", "gemini-1.5-pro", "gemini-2.0-flash"]
+
     def get_definitions(self, headers: list[str], language: str) -> dict[str, str]:
         """
         Get the definitions of the columns in the dataset using the Gemini API.

--- a/src/adtl/autoparser/language_models/openai.py
+++ b/src/adtl/autoparser/language_models/openai.py
@@ -13,6 +13,15 @@ class OpenAILanguageModel(LLMBase):
         self.client = OpenAI(api_key=api_key)
         self.model = model
 
+        if self.model not in self.valid_models:
+            raise ValueError(
+                f"Unsupported OpenAI model. Must be one of {self.valid_models}."
+            )
+
+    @property
+    def valid_models(self):
+        return ["gpt-4o-mini", "gpt-4o", "o1", "o3-mini"]
+
     def get_definitions(self, headers: list[str], language: str) -> dict[str, str]:
         """
         Get the definitions of the columns in the dataset.

--- a/src/adtl/autoparser/language_models/openai.py
+++ b/src/adtl/autoparser/language_models/openai.py
@@ -13,13 +13,13 @@ class OpenAILanguageModel(LLMBase):
         self.client = OpenAI(api_key=api_key)
         self.model = model
 
-        if self.model not in self.valid_models:
+        if self.model not in self.valid_models():
             raise ValueError(
                 f"Unsupported OpenAI model. Must be one of {self.valid_models}."
             )
 
-    @property
-    def valid_models(self):
+    @classmethod
+    def valid_models(cls):
         return ["gpt-4o-mini", "gpt-4o", "o1", "o3-mini"]
 
     def get_definitions(self, headers: list[str], language: str) -> dict[str, str]:

--- a/src/adtl/autoparser/mapping.py
+++ b/src/adtl/autoparser/mapping.py
@@ -40,8 +40,11 @@ class Mapper:
         The language of the raw data (e.g. 'fr', 'en', 'es')
     api_key
         The API key to use for the LLM
-    llm
-        The LLM to use, currently only 'openai' and 'gemini' are supported
+    llm_provider
+        The LLM API to use, currently only 'openai' and 'gemini' are supported
+    llm_model
+        The LLM model to use. If not provided, a default for the given provider will be
+        used.
     config
         The path to the configuration file to use if not using the default configuration
     """
@@ -330,7 +333,8 @@ def create_mapping(
     schema: Path,
     language: str,
     api_key: str,
-    llm: str | None = "openai",
+    llm_provider: str | None = "openai",
+    llm_model: str | None = None,
     config: Path | None = None,
     save: bool = True,
     file_name: str = "mapping_file",
@@ -351,9 +355,12 @@ def create_mapping(
     language
         Language of the source data (e.g. french, english, spanish).
     api_key
-        API key for the API defined in `llm`
-    llm
-        Which LLM to use, currently only 'openai' is supported.
+        API key for the API defined in `llm_provider`
+    llm_provider
+        Which LLM to use, currently 'openai' and 'gemini' are supported.
+    llm_model
+        Specify an LLM model to use. If not provided, a default for the given provider
+        will be used.
     config
         Path to a JSON file containing the configuration for autoparser.
     save
@@ -366,9 +373,9 @@ def create_mapping(
     pd.DataFrame
         Dataframe containing the mapping between the data dictionary and the schema.
     """
-    df = Mapper(data_dictionary, schema, language, api_key, llm, config).create_mapping(
-        save=save, file_name=file_name
-    )
+    df = Mapper(
+        data_dictionary, schema, language, api_key, llm_provider, llm_model, config
+    ).create_mapping(save=save, file_name=file_name)
 
     return df
 
@@ -385,7 +392,8 @@ def main(argv=None):
     parser.add_argument("schema", help="Schema to use")
     parser.add_argument("language", help="Language of the original data")
     parser.add_argument("api_key", help="OpenAI API key to use")
-    parser.add_argument("-l", "--llm", help="LLM API to use", default="openai")
+    parser.add_argument("-l", "--llm-provider", help="LLM API to use", default="openai")
+    parser.add_argument("-m", "--llm-model", help="LLM model to use")
     parser.add_argument(
         "-c",
         "--config",
@@ -401,7 +409,8 @@ def main(argv=None):
         Path(args.schema),
         args.language,
         args.api_key,
-        args.llm,
+        args.llm_provider,
+        args.llm_model,
         args.config,
     ).create_mapping(save=True, file_name=args.output)
 

--- a/src/adtl/autoparser/mapping.py
+++ b/src/adtl/autoparser/mapping.py
@@ -52,16 +52,17 @@ class Mapper:
         schema: Path,
         language: str,
         api_key: str | None = None,
-        llm: Literal["openai", "gemini"] | None = "openai",
+        llm_provider: Literal["openai", "gemini"] | None = "openai",
+        llm_model: str | None = None,
         config: Path | None = None,
     ):
         self.schema = read_json(schema)
         self.schema_properties = self.schema["properties"]
         self.language = language
-        if llm is None:
+        if llm_provider is None:
             self.model = None
         else:
-            self.model = setup_llm(llm, api_key)
+            self.model = setup_llm(llm_provider, api_key, model=llm_model)
 
         self.config = read_config_schema(
             config or Path(Path(__file__).parent, DEFAULT_CONFIG)

--- a/src/adtl/autoparser/mapping.py
+++ b/src/adtl/autoparser/mapping.py
@@ -62,10 +62,10 @@ class Mapper:
         self.schema = read_json(schema)
         self.schema_properties = self.schema["properties"]
         self.language = language
-        if llm_provider is None:
+        if llm_provider is None and llm_model is None:
             self.model = None
         else:
-            self.model = setup_llm(llm_provider, api_key, model=llm_model)
+            self.model = setup_llm(api_key, provider=llm_provider, model=llm_model)
 
         self.config = read_config_schema(
             config or Path(Path(__file__).parent, DEFAULT_CONFIG)

--- a/src/adtl/autoparser/mapping.py
+++ b/src/adtl/autoparser/mapping.py
@@ -392,8 +392,15 @@ def main(argv=None):
     parser.add_argument("schema", help="Schema to use")
     parser.add_argument("language", help="Language of the original data")
     parser.add_argument("api_key", help="OpenAI API key to use")
-    parser.add_argument("-l", "--llm-provider", help="LLM API to use", default="openai")
-    parser.add_argument("-m", "--llm-model", help="LLM model to use")
+    parser.add_argument(
+        "-l",
+        "--llm-provider",
+        help="LLM API to use, either 'openai' or 'gemini'",
+        default="openai",
+    )
+    parser.add_argument(
+        "-m", "--llm-model", help="LLM model to use, e.g. 'gpt-4o-mini'"
+    )
     parser.add_argument(
         "-c",
         "--config",

--- a/src/adtl/autoparser/util.py
+++ b/src/adtl/autoparser/util.py
@@ -120,7 +120,9 @@ def load_data_dict(
 
 
 def setup_llm(
-    provider: Literal["gemini", "openai"], api_key: str, model: str | None = None
+    api_key: str,
+    provider: Literal["gemini", "openai"] | None = None,
+    model: str | None = None,
 ):
     """
     Setup the LLM to use to generate descriptions.
@@ -142,13 +144,18 @@ def setup_llm(
     if api_key is None:
         raise ValueError("API key required to set up an LLM")
 
+    if provider is None and model is None:
+        raise ValueError(
+            "Either a provider, a model or both must be provided to set up the LLM"
+        )
+
     kwargs = {"api_key": api_key}
     if model is not None:
         kwargs["model"] = model
 
-    if provider == "openai":
+    if provider == "openai" or model in OpenAILanguageModel.valid_models():
         return OpenAILanguageModel(**kwargs)
-    elif provider == "gemini":
+    elif provider == "gemini" or model in GeminiLanguageModel.valid_models():
         return GeminiLanguageModel(**kwargs)
     else:
         raise ValueError(f"Unsupported LLM provider: {provider}")

--- a/src/adtl/autoparser/util.py
+++ b/src/adtl/autoparser/util.py
@@ -8,7 +8,7 @@ import difflib
 import json
 import re
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Literal
 
 import pandas as pd
 import tomli
@@ -119,7 +119,9 @@ def load_data_dict(
     return data_dict
 
 
-def setup_llm(provider, api_key):
+def setup_llm(
+    provider: Literal["gemini", "openai"], api_key: str, model: str | None = None
+):
     """
     Setup the LLM to use to generate descriptions.
 
@@ -128,18 +130,26 @@ def setup_llm(provider, api_key):
 
     Parameters
     ----------
-    key
+    provider
+        Name of the LLM provider to use (openai or gemini)
+    api_key
         API key
-    name
-        Name of the LLM to use (currently only OpenAI and Gemini are supported)
+    model
+        Name of the LLM model to use (must support Structured Outputs for OpenAI, or the
+        equivalent responseSchema for Gemini). If not provided, the default for each
+        provider will be used.
     """
     if api_key is None:
         raise ValueError("API key required to set up an LLM")
 
+    kwargs = {"api_key": api_key}
+    if model is not None:
+        kwargs["model"] = model
+
     if provider == "openai":  # pragma: no cover
-        return OpenAILanguageModel(api_key=api_key)
+        return OpenAILanguageModel(**kwargs)
     elif provider == "gemini":  # pragma: no cover
-        return GeminiLanguageModel(api_key=api_key)
+        return GeminiLanguageModel(**kwargs)
     else:
         raise ValueError(f"Unsupported LLM provider: {provider}")
 

--- a/src/adtl/autoparser/util.py
+++ b/src/adtl/autoparser/util.py
@@ -146,9 +146,9 @@ def setup_llm(
     if model is not None:
         kwargs["model"] = model
 
-    if provider == "openai":  # pragma: no cover
+    if provider == "openai":
         return OpenAILanguageModel(**kwargs)
-    elif provider == "gemini":  # pragma: no cover
+    elif provider == "gemini":
         return GeminiLanguageModel(**kwargs)
     else:
         raise ValueError(f"Unsupported LLM provider: {provider}")

--- a/tests/test_autoparser/test_dict_writer.py
+++ b/tests/test_autoparser/test_dict_writer.py
@@ -105,13 +105,13 @@ def test_missing_key_error():
 def test_wrong_llm_error():
     with pytest.raises(ValueError, match="Unsupported LLM provider: fish"):
         DictWriter(config=Path(CONFIG_PATH)).generate_descriptions(
-            "fr", SOURCES + "animals_dd.csv", key="a12b3c", llm="fish"
+            "fr", SOURCES + "animals_dd.csv", key="a12b3c", llm_provider="fish"
         )
 
 
 def test_init_with_llm():
     # test no errors occur
-    writer = DictWriter(config=Path(CONFIG_PATH), api_key="1234", llm="openai")
+    writer = DictWriter(config=Path(CONFIG_PATH), api_key="1234", llm_provider="openai")
     assert isinstance(writer.model, OpenAILanguageModel)
 
 

--- a/tests/test_autoparser/test_dict_writer.py
+++ b/tests/test_autoparser/test_dict_writer.py
@@ -148,10 +148,10 @@ def test_main_cli_error_descrip_no_apikey(tmp_path):
 class DictTest(DictWriter):
     # override the __init__ method to avoid calling any LLM API's, and fill with dummy
     # data from testing_data.py
-    def __init__(self, config, llm=None, api_key=None):
+    def __init__(self, config, llm_provider=None, api_key=None):
         super().__init__(
             config,
-            llm,
+            llm_provider,
             api_key,
         )
 

--- a/tests/test_autoparser/test_gemini.py
+++ b/tests/test_autoparser/test_gemini.py
@@ -1,5 +1,6 @@
 "Tests the OpenAILanguageModel class."
 
+import pytest
 from google.generativeai import protos
 from google.generativeai.types import GenerateContentResponse
 from testing_data_animals import get_definitions, map_fields, map_values
@@ -12,6 +13,16 @@ def test_init():
 
     assert model.client is not None
     assert model.model == "gemini-1.5-flash"
+
+
+def test_init_invalid_model_raises():
+    with pytest.raises(ValueError, match="Unsupported Gemini model. Must be one of"):
+        GeminiLanguageModel("1234", model="invalid_model")
+
+
+def test_init_with_model():
+    model = GeminiLanguageModel("1234", model="gemini-2.0-flash")
+    assert model.model == "gemini-2.0-flash"
 
 
 def test_get_definitions(monkeypatch):

--- a/tests/test_autoparser/test_mapper.py
+++ b/tests/test_autoparser/test_mapper.py
@@ -226,7 +226,7 @@ def test_mapper_class_init_raises():
             Path("tests/test_autoparser/schemas/animals.schema.json"),
             "fr",
             api_key="1234",
-            llm="fish",
+            llm_provider="fish",
         )
 
 
@@ -235,7 +235,7 @@ def test_mapper_class_init():
         "tests/test_autoparser/sources/animals_dd_described.csv",
         Path("tests/test_autoparser/schemas/animals.schema.json"),
         "fr",
-        llm=None,
+        llm_provider=None,
     )
 
     assert mapper.language == "fr"

--- a/tests/test_autoparser/test_mapper.py
+++ b/tests/test_autoparser/test_mapper.py
@@ -18,7 +18,14 @@ class MapperTest(Mapper):
     # override the __init__ method to avoid calling any LLM API's, and fill with dummy
     # data from testing_data.py
     def __init__(
-        self, data_dictionary, schema, language, api_key=None, llm=None, config=None
+        self,
+        data_dictionary,
+        schema,
+        language,
+        api_key=None,
+        llm_provider=None,
+        llm_model=None,
+        config=None,
     ):
         super().__init__(
             data_dictionary,

--- a/tests/test_autoparser/test_openai.py
+++ b/tests/test_autoparser/test_openai.py
@@ -2,6 +2,7 @@
 
 import datetime
 
+import pytest
 from openai.types.chat.parsed_chat_completion import (
     ParsedChatCompletion,
     ParsedChatCompletionMessage,
@@ -18,6 +19,16 @@ def test_init():
 
     assert model.client is not None
     assert model.model == "gpt-4o-mini"
+
+
+def test_init_invalid_model_raises():
+    with pytest.raises(ValueError, match="Unsupported OpenAI model. Must be one of"):
+        OpenAILanguageModel("1234", model="invalid_model")
+
+
+def test_init_with_model():
+    model = OpenAILanguageModel("1234", model="o3-mini")
+    assert model.model == "o3-mini"
 
 
 def test_get_definitions(monkeypatch):

--- a/tests/test_autoparser/test_utils.py
+++ b/tests/test_autoparser/test_utils.py
@@ -109,6 +109,11 @@ def test_setup_llm_bad_provider():
         setup_llm("fish", "abcd")
 
 
+def test_setup_llm_provide_model():
+    model = setup_llm("gemini", "abcd", "gemini-2.0-flash")
+    assert model.model == "gemini-2.0-flash"
+
+
 @pytest.mark.parametrize(
     "input, expected", [(("fish", ["fishes"]), "fishes"), (("fish", ["shark"]), None)]
 )

--- a/tests/test_autoparser/test_utils.py
+++ b/tests/test_autoparser/test_utils.py
@@ -6,6 +6,7 @@ import numpy.testing as npt
 import pandas as pd
 import pytest
 
+from adtl.autoparser.language_models.gemini import GeminiLanguageModel
 from adtl.autoparser.util import (
     check_matches,
     load_data_dict,
@@ -101,17 +102,30 @@ def test_load_data_dict():
 
 def test_setup_llm_no_key():
     with pytest.raises(ValueError, match="API key required to set up an LLM"):
-        setup_llm("openai", None)
+        setup_llm(None, provider="openai")
 
 
 def test_setup_llm_bad_provider():
     with pytest.raises(ValueError, match="Unsupported LLM provider: fish"):
-        setup_llm("fish", "abcd")
+        setup_llm("abcd", provider="fish")
 
 
 def test_setup_llm_provide_model():
-    model = setup_llm("gemini", "abcd", "gemini-2.0-flash")
+    model = setup_llm("abcd", provider="gemini", model="gemini-2.0-flash")
     assert model.model == "gemini-2.0-flash"
+
+
+def test_setup_llm_provide_model_no_provider():
+    model = setup_llm("abcd", model="gemini-2.0-flash")
+    assert isinstance(model, GeminiLanguageModel)
+    assert model.model == "gemini-2.0-flash"
+
+
+def test_setup_llm_no_provider_no_model():
+    with pytest.raises(
+        ValueError, match="Either a provider, a model or both must be provided"
+    ):
+        setup_llm("1234")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Adds the ability for a user to select which LLM model (from the openai or gemini range) they wish to use, while keeping `gpt-4o-mini` and `gemini-1.5-flash` as the defaults.