### PR TITLE
Type coercion

### DIFF
--- a/docs/specification.md
+++ b/docs/specification.md
@@ -14,6 +14,17 @@ created in parallel from one source file.
 [JSON schema](../schemas/dev.schema.json): This is a partial JSON schema to validate
 adtl parser files.
 
+## Type conversion
+
+If field data types are specified in the target schema, ADTL will attempt to
+coerce the parsed source data into that format. In the case of numeric data -> integer types,
+the value will be rounded to the nearest whole number to conform to the schema. If the
+value can't be converted, the original data type will be returned.
+
+Where data types aren't provided, ADTL will return numeric data as-is, and attempt to cast
+string values first as integers (no rounding applied), then floats, returning the original format
+if these both fail.
+
 ## Metadata
 
 These metadata fields are defined under a header key `adtl`.

--- a/src/adtl/parser.py
+++ b/src/adtl/parser.py
@@ -426,6 +426,10 @@ class Parser:
         """
 
         kind = self.tables[table].get("kind")
+        if self.schemas.get(table):
+            schema_p = self.schemas[table]["properties"]
+        else:
+            schema_p = None
 
         if kind == "oneToMany":
             data = []
@@ -436,7 +440,12 @@ class Parser:
                     data.append(
                         remove_null_keys(
                             {
-                                attr: get_value(row, match[attr], self.ctx(attr))
+                                attr: get_value(
+                                    row,
+                                    match[attr],
+                                    self.ctx(attr),
+                                    schema_p[attr].get("type") if schema_p else None,
+                                )
                                 for attr in set(match.keys()) - {"if"}
                             }
                         )
@@ -447,7 +456,12 @@ class Parser:
         else:  # groupBy
             parsed_row = {}
             for attr in self.spec[table]:
-                value = get_value(row, self.spec[table][attr], self.ctx(attr))
+                value = get_value(
+                    row,
+                    self.spec[table][attr],
+                    self.ctx(attr),
+                    schema_p[attr].get("type") if schema_p else None,
+                )
                 if value is not None and value != []:
                     parsed_row[attr] = value
             return remove_null_keys(parsed_row)

--- a/src/adtl/util.py
+++ b/src/adtl/util.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 
 logger = logging.getLogger(__name__)

--- a/src/adtl/util.py
+++ b/src/adtl/util.py
@@ -11,7 +11,6 @@ def convert_to_schema_type(value, target_type: str | list[str]):
         "string": str,
         "integer": int,
         "number": float,
-        "boolean": bool,
     }
 
     if isinstance(target_type, str):
@@ -28,7 +27,8 @@ def convert_to_schema_type(value, target_type: str | list[str]):
                         return int(round(float(value)))
                     except (ValueError, TypeError):
                         logger.debug(f"Could not convert value {value} to integer")
+                        return value
 
-                logger.debug(f"Could not coerce value {value} to type {tt}")
+                logger.debug(f"Could not convert value {value} to type {tt}")
 
     return value

--- a/src/adtl/util.py
+++ b/src/adtl/util.py
@@ -1,0 +1,34 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def convert_to_schema_type(value, target_type: str | list[str]):
+    """
+    Convert value to the target type specified in a JSON schema.
+    """
+    type_casters = {
+        "string": str,
+        "integer": int,
+        "number": float,
+        "boolean": bool,
+    }
+
+    if isinstance(target_type, str):
+        target_type = [target_type]
+
+    for tt in target_type:
+        if tt in type_casters:
+            try:
+                return type_casters[tt](value)
+            except (ValueError, TypeError):
+                if tt == "integer":
+                    # Special case for converting float to integer with rounding
+                    try:
+                        return int(round(float(value)))
+                    except (ValueError, TypeError):
+                        logger.debug(f"Could not convert value {value} to integer")
+
+                logger.debug(f"Could not coerce value {value} to type {tt}")
+
+    return value

--- a/tests/test_adtl/parsers/test.schema.json
+++ b/tests/test_adtl/parsers/test.schema.json
@@ -45,6 +45,15 @@
       ],
       "description": "Sex at birth",
       "category": "demographics"
+    },
+    "ethnicity": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "uniqueItems": true,
+      "description": "Ethnicity",
+      "category": "demographics"
     }
   }
 }

--- a/tests/test_adtl/schemas/epoch-data.schema.json
+++ b/tests/test_adtl/schemas/epoch-data.schema.json
@@ -27,6 +27,9 @@
     },
     "followup_cough": {
       "description": "Follow-up cough field"
+    },
+    "headache": {
+      "description": "Standard headache field"
     }
   }
 }

--- a/tests/test_adtl/test_util.py
+++ b/tests/test_adtl/test_util.py
@@ -1,0 +1,50 @@
+import pytest
+
+import adtl.util as util
+
+
+@pytest.mark.parametrize(
+    "value, target, expected_value",
+    [
+        ("123", "string", "123"),
+        (123, "string", "123"),
+        (123.12, "integer", 123),
+        ("true", "boolean", "true"),
+        ("15", "number", 15.0),
+    ],
+    ids=[
+        "string to string",
+        "int to string",
+        "float to int",
+        "string to bool",
+        "string to number",
+    ],
+)
+def test_convert_type_to_schema(value, target, expected_value):
+    """
+    Test that the get_value function coerces the value to the type specified in the schema.
+    """
+    new_value = util.convert_to_schema_type(value, target)
+    assert new_value == expected_value
+
+
+@pytest.mark.parametrize(
+    "value, target, expected_log",
+    [
+        ("fish", "integer", "Could not convert value fish to integer"),
+        ("fish", "number", "Could not convert value fish to type number"),
+    ],
+    ids=[
+        "string to int",
+        "string to number",
+    ],
+)
+def test_convert_type_to_schema_failure(value, target, expected_log, caplog):
+    """
+    Test that logger writes a debug message when coercion fails.
+    """
+    with caplog.at_level("DEBUG", logger="adtl.util"):
+        new_value = util.convert_to_schema_type(value, target)
+    assert new_value == value
+    # Check if expected log message is in caplog
+    assert any(expected_log in msg for msg in caplog.text.splitlines())


### PR DESCRIPTION
Fixes #153 

Where a type is specified for a field in a schema, ADTL will attempt to coerce any returned value to that type. In the case of float -> int where there are non-zero decimals, the float will be rounded.